### PR TITLE
feat: add argocd project and applications creation from `tekton-apps` chart

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 *.pem
 *.pub
+.idea

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -13,7 +13,7 @@ triggersVersions: "v0.16.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.14
+version: 0.1.15
 
 
 maintainers:
@@ -31,6 +31,8 @@ description: |
   - configmaps for each app
   - triggerbindings for each app
   - kubernetes job to make sure the PVCs are bound and argocd marks the app as healthy
+  - argocd project for each app
+  - argocd application for each app component
 
   ## `example usage with argocd`
 
@@ -88,6 +90,14 @@ description: |
           apps:
             - project: vp
               enabled: true
+              argocd:
+                labels:
+                  created-by: xxx
+                  ops-main: xxx
+                  ops-secondary: xxx
+                  pm: xxx
+                  tm: xxx
+                namespace: prod
               mailList: vp@site.com
               devopsMailList: devops+vp@site.com
               jiraURL: https://site.atlassian.net/browse/vp
@@ -203,6 +213,14 @@ description: |
             apps:
               - project: xxx
                 enabled: true
+                argocd:
+                  labels:
+                    created-by: xxx
+                    ops-main: xxx
+                    ops-secondary: xxx
+                    pm: xxx
+                    tm: xxx
+                  namespace: prod
                 mailList: xxx@saritasa.com
                 devopsMailList: devops+xxx@saritasa.com
                 jiraURL: https://saritasa.atlassian.net/browse/xxx
@@ -266,4 +284,138 @@ description: |
         syncOptions:
           - CreateNamespace=true
 
+    ```
+
+    This chart also has flexible implementation to generate ArgoCD Project and Application manifests. There are below additional
+    parameters, which allow you to override default helm chart generation behavior.
+
+    Project extra vars
+
+    - apps[PROJECT].argocd.syncWave - set custom Project sync wave (default: "200")
+    - apps[PROJECT].argocd.sourceRepos[] - set custom Project source repositories as list of strings
+      (default: [<apps[PROJECT].kubernetesRepository.url>])
+
+    Application extra vars
+
+    - apps[PROJECT].components[NAME].argocd.appName - set custom Application name for the component
+      (default: "<apps[PROJECT].project>-<apps[PROJECT].components[NAME].name>-<environment>")
+    - apps[PROJECT].components[NAME].argocd.syncWave - set custom Application sync wave (default: "210")
+    - apps[PROJECT].components[NAME].argocd.source.path - set custom Application source path
+      (default: "apps/<apps[PROJECT].components[NAME].name>/manifests/<environment>")
+    - apps[PROJECT].components[NAME].argocd.source.repoUrl - set custom Application source repository url
+      (default: "<apps[PROJECT].kubernetesRepository.url>")
+    - apps[PROJECT].components[NAME].argocd.source.targetRevision - set custom Application source
+      repository target revision - branch or tag (default: "<apps[PROJECT].kubernetesRepository.branch>")
+
+    Example of helm chart with all extra parameters in `apps` section:
+
+    ```yaml
+    apiVersion: argoproj.io/v1alpha1
+    kind: Application
+    metadata:
+      name: tekton-apps
+      namespace: argo-cd
+      finalizers:
+      - resources-finalizer.argocd.argoproj.io
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "41"
+    spec:
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: ci
+      project: default
+      source:
+        chart: saritasa-tekton-apps
+        helm:
+          values: |
+            environment: staging
+            ...
+            apps:
+              - project: xxx
+                enabled: true
+                argocd:
+                  labels:
+                    created-by: xxx
+                    ops-main: xxx
+                    ops-secondary: xxx
+                    pm: xxx
+                    tm: xxx
+                  namespace: prod
+                  syncWave: "200"
+                  sourceRepos:
+                    - git@github.com:saritasa-nest/custom-repo-1.git
+                    - git@github.com:saritasa-nest/custom-repo-2.git
+                mailList: xxx@saritasa.com
+                devopsMailList: devops+xxx@saritasa.com
+                jiraURL: https://saritasa.atlassian.net/browse/xxx
+                tektonURL: https://tekton.site.com/#/namespaces/ci/pipelineruns
+                slack: client-xxx-ci
+                kubernetesRepository:
+                  name: xxx-kubernetes-aws
+                  branch: main
+                  url: git@github.com:saritasa-nest/xxx-kubernetes-aws.git
+
+                components:
+                  - name: backend
+                    argocd:
+                      appName: custom-backend-app-name
+                      syncWave: "210"
+                      source:
+                        path: "custom/dir"
+                        repoUrl: git@github.com:saritasa-nest/custom-repo-1.git
+                        targetRevision: custom-v1
+                    repository: xxx-backend
+                    pipeline: buildpack
+                    applicationURL: https://api.site.com
+                    eventlistener:
+                      template: buildpack-backend-build-pipeline-trigger-template
+                    extraBuildConfigParams: # what additional K/V pairs you want to add into the build-pipeline-config configmap
+                      KEY: value
+                    triggerBinding:
+                      - name: docker_registry_repository
+                        value: XXX.dkr.ecr.us-west-2.amazonaws.com/xxx/dev/backend
+                      - name: buildpack_builder_image
+                        value: XXX.dkr.ecr.us-west-2.amazonaws.com/xxx/dev/buildpacks/google/builder:v1
+                      - name: buildpack_runner_image
+                        value: XXX.dkr.ecr.us-west-2.amazonaws.com/xxx/dev/buildpacks/google/runner:v1
+
+                  - name: frontend
+                    argocd:
+                      appName: custom-frontend-app-name
+                      syncWave: "210"
+                      source:
+                        path: "custom/dir"
+                        repoUrl: git@github.com:saritasa-nest/custom-repo-1.git
+                        targetRevision: custom-v1
+                    repository: xxx-frontend
+                    pipeline: buildpack
+                    applicationURL: https://site.com
+                    eventlistener:
+                      enableWebhookSecret: false
+                      filter: (body.ref.startsWith('refs/heads/develop') || body.ref.startsWith('refs/heads/release/'))
+                      template: buildpack-frontend-build-pipeline-trigger-template
+                      extraOverlays: []
+                      # - key: truncated_sha
+                      #   expression: "body.head_commit.id.truncate(7)"
+                      eventTypes: ["pull_request", "push"]
+                    extraBuildConfigParams: {}
+                    triggerBinding:
+                      - name: docker_registry_repository
+                        value: XXX.dkr.ecr.us-west-2.amazonaws.com/xxx/dev/frontend
+                      - name: buildpack_builder_image
+                        value: XXX.dkr.ecr.us-west-2.amazonaws.com/xxx/dev/buildpacks/paketo/builder:full
+                      - name: buildpack_runner_image
+                        value: XXX.dkr.ecr.us-west-2.amazonaws.com/xxx/dev/buildpacks/paketo/runner:full
+                      - name: source_subpath
+                        value: dist/web
+
+        repoURL: https://saritasa-nest.github.io/saritasa-devops-helm-charts/
+        targetRevision: "0.1.14"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
     ```

--- a/charts/tekton-apps/templates/argocd_applications.yaml
+++ b/charts/tekton-apps/templates/argocd_applications.yaml
@@ -1,0 +1,38 @@
+{{ if .Values.apps }}
+{{- range $project := .Values.apps }}
+{{- if and $project.enabled $project.argocd}}
+{{- range $component := $project.components }}
+
+{{- /* initialize `argocd` variable with either `$component.argocd` dict if it exists or with empty dict */}}
+{{ $argocd := ternary $component.argocd dict (hasKey $component "argocd") -}}
+
+{{- /* initialize `argocdSource` variable with either `$argocd.source` dict if it exists or with empty dict */}}
+{{ $argocdSource := ternary $argocd.source dict (hasKey $argocd "source") -}}
+
+apiVersion: argoproj.io/v1alpha1
+kind: Application
+metadata:
+  name: {{ $argocd.appName | default (printf "%s-%s-%s" $project.project $component.name $.Values.environment) }}
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $argocd.syncWave | default "210" | quote }}
+spec:
+  destination:
+    namespace: {{ $project.argocd.namespace }}
+    server: https://kubernetes.default.svc
+  project: {{ $project.project }}
+  source:
+    path: {{ $argocdSource.path | default (printf "apps/%s/manifests/%s" $component.name $.Values.environment) }}
+    repoURL: {{ $argocdSource.repoUrl | default $project.kubernetesRepository.url }}
+    targetRevision: {{ $argocdSource.targetRevision | default $project.kubernetesRepository.branch }}
+  syncPolicy:
+    automated:
+      prune: true
+      selfHeal: true
+    syncOptions:
+      - CreateNamespace=true
+---
+{{- end }} {{- /* range component */}}
+{{- end }} {{- /* if project.enabled and project.argocd */}}
+{{- end }} {{- /* range project */}}
+{{- end }} {{- /* if apps */}}

--- a/charts/tekton-apps/templates/argocd_projects.yaml
+++ b/charts/tekton-apps/templates/argocd_projects.yaml
@@ -1,0 +1,32 @@
+{{ if .Values.apps }}
+{{- range $project := .Values.apps }}
+{{- if and $project.enabled $project.argocd }}
+
+{{- /* initialize `sourceRepos` variable with either `$project.argocd.sourceRepos` list
+    if it is set or create a new default list from `$project.kubernetesRepository.url` only */}}
+{{ $sourceRepos := ternary $project.argocd.sourceRepos (list $project.kubernetesRepository.url) (hasKey $project.argocd "sourceRepos") -}}
+
+apiVersion: argoproj.io/v1alpha1
+kind: AppProject
+metadata:
+  labels: {{- toYaml $project.argocd.labels | nindent 4 }}
+  name: {{ $project.project }}
+  namespace: argo-cd
+  annotations:
+    argocd.argoproj.io/sync-wave: {{ $project.argocd.syncWave | default "200" | quote }}
+spec:
+  destinations:
+  - namespace: {{ $project.argocd.namespace }}
+    server: https://kubernetes.default.svc
+  - namespace: ci
+    server: https://kubernetes.default.svc
+  orphanedResources:
+    warn: true
+  sourceRepos: {{ toYaml $sourceRepos | nindent 4 }}
+  clusterResourceWhitelist:
+  - group: '*'
+    kind: '*'
+---
+{{- end }} {{- /* if project.enabled and project.argocd */}}
+{{- end }} {{- /* range project */}}
+{{- end }} {{- /* if apps */}}

--- a/charts/tekton-apps/values.yaml
+++ b/charts/tekton-apps/values.yaml
@@ -48,10 +48,19 @@ eventlistener:
     #   - key: branch_name
     #     expression: "body.ref.split('/')[2]"
 
+
 # -- list of projects and the project's apps to be triggered
 apps: []
   # - project: xxx
   #   enabled: true
+  #   argocd:
+  #     labels:
+  #       created-by: xxx
+  #       ops-main: xxx
+  #       ops-secondary: xxx
+  #       pm: xxx
+  #       tm: xxx
+  #     namespace: prod
   #   mailList: xxx@saritasa.com
   #   devopsMailList: devops+xxx@saritasa.com
   #   jiraURL: https://saritasa.atlassian.net/browse/xxx
@@ -61,7 +70,7 @@ apps: []
   #     name: xxx-kubernetes-aws
   #     branch: main
   #     url: git@github.com:saritasa-nest/xxx-kubernetes-aws.git
-
+  #
   #   components:
   #     - name: backend
   #       repository: xxx-backend
@@ -77,8 +86,8 @@ apps: []
   #         - name: buildpack_builder_image
   #           value: XXX.dkr.ecr.us-west-2.amazonaws.com/xxx/dev/buildpacks/google/builder:v1
   #         - name: buildpack_runner_image
-  #           value: XXX.dkr.ecr.us-west-2.amazonaws.com/xxx/dev/buildpacks/google/runner:v1
-
+  #           value: XXX.dkr.ecr.us-west-2.amazonaws.com/xxx/dev/buildpacks/google/runner:v
+  #
   #     - name: frontend
   #       repository: xxx-frontend
   #       pipeline: buildpack


### PR DESCRIPTION
Add possibility to create argocd Project and Applications from `tekton-apps` helm chart. They may be configured by passing these parameters:

1. values.yaml - `apps` param:
https://github.com/saritasa-nest/saritasa-devops-helm-charts/blob/400e9572bdd69e0a5d67085e9434a9d2db3e6a50/charts/tekton-apps/values.yaml#L56-L63

Also there are flexible options to pass additional vars for better Project and Application customization:

https://github.com/saritasa-nest/saritasa-devops-helm-charts/blob/400e9572bdd69e0a5d67085e9434a9d2db3e6a50/charts/tekton-apps/README.md?plain=1#L307-L439

