### PR TITLE
feat: add 1.5.0 tag as bump of 1.4.0

### DIFF
--- a/charts/tekton/Chart.yaml
+++ b/charts/tekton/Chart.yaml
@@ -14,7 +14,7 @@ triggersVersions: "v0.16.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.4
+version: 0.1.5
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton/README.md
+++ b/charts/tekton/README.md
@@ -31,7 +31,7 @@ saritasa-tekton
 
 ## `chart.version`
 
-![Version: 0.1.4](https://img.shields.io/badge/Version-0.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.2](https://img.shields.io/badge/AppVersion-v0.28.2-informational?style=flat-square)
+![Version: 0.1.5](https://img.shields.io/badge/Version-0.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.2](https://img.shields.io/badge/AppVersion-v0.28.2-informational?style=flat-square)
 
 ## Maintainers
 


### PR DESCRIPTION
Simply bumped current 1.4.0 version to 1.5.0 because I had unresolvable issue with cached tekton on PGA cluster