### PR TITLE
feat: Add Kaniko base image parameter

### DIFF
--- a/charts/tekton-pipelines/templates/kaniko/pipeline.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/pipeline.yaml
@@ -53,6 +53,10 @@ spec:
           value: $(params.docker_registry)
         - name: environment
           value: "$(params.environment)"
+        {{ if .Values.kaniko.baseDockerImage }}
+        - name: base_docker_image
+          value: "$(params.base_docker_image)"
+        {{ end }}
         - name: docker_file
           value: "$(params.docker_file)"
         - name: docker_context

--- a/charts/tekton-pipelines/templates/kaniko/tasks/kaniko.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/tasks/kaniko.yaml
@@ -26,6 +26,11 @@ spec:
       type: string
       description: name of the argocd application we're going to deploy/sync
 
+    {{ if .Values.kaniko.baseDockerImage }}
+    - name: base_docker_image
+      type: string
+      description: docker image that application extends
+    {{ end }}
     - name: docker_registry
       type: string
       description: aws private ecr registry address
@@ -81,6 +86,9 @@ spec:
       args:
         - $(params.extra_args[*])
         - --build-arg=ENVIRONMENT=$(params.environment)
+        {{ if .Values.kaniko.baseDockerImage }}
+        - --build-arg=BASE_IMAGE=$(params.base_docker_image)
+        {{ end }}
         - --dockerfile=$(resources.inputs.app.path)/$(params.docker_file)
         - --context=$(resources.inputs.app.path)/$(params.docker_context)
         - --destination=$(resources.outputs.image.url)

--- a/charts/tekton-pipelines/templates/kaniko/trigger-template.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/trigger-template.yaml
@@ -15,6 +15,11 @@ spec:
     - name: kubernetes_repository_ssh_url
       description: git repository ssh url for kubernetes manifests repo
 
+    {{ if .Values.kaniko.baseDockerImage }}
+    - name: base_docker_image
+      default: {{ .Values.kaniko.baseDockerImage }}
+      description: location of the dockerfile, should be Dockerfile if it is in the root of the repository
+    {{ end }}
     - name: docker_file
       default: Dockerfile
       description: location of the dockerfile, should be Dockerfile if it is in the root of the repository

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -300,6 +300,8 @@ buildpacks:
 kaniko:
   # -- should we enable the kaniko pipeline
   enabled: false
+  # If not null Kaniko Pipeline will pass --build-arg BASE_IMAGE=<baseDockerImage> to Dockerfile
+  baseDockerImage: ""
 
 wordpress:
   # -- should we enable the wordpress pipeline


### PR DESCRIPTION
Now base image is hardcoded in `Dockerfile` first string, ex.:
```docker
FROM 965067289393.dkr.ecr.us-west-2.amazonaws.com/saritasa/legacy/php:centos7-php71-nginx-phpfpm

RUN yum install -y php71w-opcache php71w-pecl-redis && yum clean all
```

and includes registry address. But for dev and prod these registries will be different, so we must merge `develop` and `main` branches carefully in order not to break builds. Instead this can ba passed as an argument and in Dockerfile we will have

```docker
ARG BASE_IMAGE=965067289393.dkr.ecr.us-west-2.amazonaws.com/saritasa/legacy/php:centos7-php71-nginx-phpfpm
FROM $BASE_IMAGE

RUN yum install -y php71w-opcache php71w-pecl-redis && yum clean all
```

As well, we can override it in project tekton trigger binding - to have different base images for different projects.
Ideally it would be good to have pipeline to build base image automatically on changes of a certain file, but do not deploy anything.

_This is a proof of concept, so I didn't change chart version yet_