### PR TITLE
fix: adjust triggerbinding generation template

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,6 @@ name: Release Charts
 on:
   push:
     branches:
-      - main
       - feature/*
       - fix/*
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - main
       - feature/*
+      - fix/*
 
 jobs:
   release:

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -13,7 +13,7 @@ triggersVersions: "v0.16.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.17
+version: 0.1.18
 
 
 maintainers:

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 0.1.17](https://img.shields.io/badge/Version-0.1.17-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.2](https://img.shields.io/badge/AppVersion-v0.28.2-informational?style=flat-square)
+![Version: 0.1.18](https://img.shields.io/badge/Version-0.1.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.2](https://img.shields.io/badge/AppVersion-v0.28.2-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-apps/templates/general/triggerbindings.yaml
+++ b/charts/tekton-apps/templates/general/triggerbindings.yaml
@@ -39,13 +39,26 @@ spec:
     value: {{ $.Values.defaultRegistry }}
   {{- end }}
   {{- toYaml $component.triggerBinding | nindent 2 }}
+
+  {{- if $argocdSource }}
+  # ! OLD WAY:
+  # If you see this message - pls transfer kubernetes manifests into dedicated kubernetes git repo
+  # if we want to support old ways when our kubernetes manifests where specifically declared inside
+  # actual backend or frontend repos. In new approach we have isolated kubernetes repository with manifests
   - name: kubernetes_repository_ssh_url
     value: {{ $argocdSource.repoUrl | default ($project.kubernetesRepository).url }}
   - name: kubernetes_branch
     value: {{ $argocdSource.targetRevision | default ($project.kubernetesRepository).branch }}
   - name: kubernetes_repository_kustomize_path
     value: {{ $argocdSource.path | default (printf "apps/%s/manifests/%s" $component.name $projectEnvironment) }}
+  {{- else }}
+  # defaults
+  - name: kubernetes_repository_ssh_url
+    value: {{ $project.kubernetesRepository.url }}
+  {{- include "tekton-apps.get-triggerbinding-value-or-default" (dict "triggerBinding" $component.triggerBinding "name" "kubernetes_branch" "default" ($project.kubernetesRepository).branch ) | nindent 2 }}
+  {{- include "tekton-apps.get-triggerbinding-value-or-default" (dict "triggerBinding" $component.triggerBinding "name" "kubernetes_repository_kustomize_path" "default" (printf "apps/%s/manifests/%s" $component.name $projectEnvironment) ) | nindent 2 }}
   {{- include "tekton-apps.get-triggerbinding-value-or-default" (dict "triggerBinding" $component.triggerBinding "name" "source_subpath" "default" "." ) | nindent 2 }}
+  {{- end}}
 ---
 
 {{- end }} # if not component.wordpress


### PR DESCRIPTION
this PR fixes double entry in the triggerbinding
![image](https://user-images.githubusercontent.com/70822710/167055464-151c2144-9af3-40b7-bb36-cea26ff5e9ec.png)

kubernetes_branch is listed twice
![image](https://user-images.githubusercontent.com/70822710/167055623-b70d6c7e-4952-4f62-ae5a-a513d04486b3.png)

an example of the values.yaml file

```yaml
environment: staging

gitBranchPrefixes:
  - staging
  - release

storageClassName: "gp2"

aws:
  region: "us-east-2"
  dns: proxylegalstaging.com

defaultRegistry: 833737135757.dkr.ecr.us-east-2.amazonaws.com

argocd:
  server: deploy.proxylegalstaging.com

eventlistener:
  enableWebhookSecret: true

apps:
  - project: nmbl
    enabled: true
    argocd:
      labels:
        created-by: DmitrySemenov
        ops-main: DmitrySemenov
        ops-secondary: KseniyaShaydurova
        pm: VadikKuznetsov
        tm: AlekseyBashirov
      namespace: staging
      syncWave: 200
    mailList: nmbl@saritasa.com
    devopsMailList: devops+nmbl@saritasa.com
    jiraURL: https://saritasa.atlassian.net/browse/NMBLCLD
    tektonURL: https://tekton.proxylegalstaging.com/#/namespaces/ci/pipelineruns
    slack: client-nmbl-ci
    kubernetesRepository:
      name: nmbl-kubernetes-aws
      branch: feature/add-staging
      url: git@github.com:saritasa-nest/nmbl-kubernetes-aws.git

    components:
      - name: backend
        repository: nmbl-backend
        pipeline: buildpack-django-build-pipeline
        applicationURL: https://api.proxylegalstaging.com
        argocd:
          syncWave: 210
        eventlistener:
          template: buildpack-django-build-pipeline-trigger-template
        triggerBinding:
          - name: docker_registry_repository
            value: 833737135757.dkr.ecr.us-east-2.amazonaws.com/nmbl/staging/backend
          - name: buildpack_builder_image
            value: 833737135757.dkr.ecr.us-east-2.amazonaws.com/nmbl/staging/buildpacks/google/builder:latest
          - name: buildpack_runner_image
            value: 833737135757.dkr.ecr.us-east-2.amazonaws.com/nmbl/staging/buildpacks/google/runner:latest
          - name: kubernetes_branch
            value: feature/add-staging

      - name: frontend
        repository: nmbl-frontend
        pipeline: buildpack-frontend-build-pipeline
        applicationURL: https://proxylegalstaging.com
        argocd:
          syncWave: 220
        eventlistener:
          template: buildpack-frontend-build-pipeline-trigger-template
          # TODO: Ksusha - pls fix once you finalize the PR
          # https://github.com/saritasa-nest/nmbl-frontend/pull/1#pullrequestreview-962791245
          gitWebhookBranches:
            - feature/add-ci-cd
        triggerBinding:
          - name: docker_registry_repository
            value: 833737135757.dkr.ecr.us-east-2.amazonaws.com/nmbl/staging/frontend
          - name: buildpack_builder_image
            value: 833737135757.dkr.ecr.us-east-2.amazonaws.com/nmbl/staging/buildpacks/paketo/builder:latest
          - name: buildpack_runner_image
            value: 833737135757.dkr.ecr.us-east-2.amazonaws.com/nmbl/staging/buildpacks/paketo/runner:latest
          - name: source_subpath
            value: dist
          - name: kubernetes_branch
            value: feature/add-staging

# make sure PVCs are bound after the chart is synced
# by temporarily mount them into short-live job.
runPostInstallMountPvcJob: false

```