### PR TITLE
feat: update gitversion image for dotnet

### DIFF
--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -14,7 +14,7 @@ triggersVersions: "v0.16.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.16
+version: 0.1.17
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -187,7 +187,7 @@ buildpacks:
 
         - name: get-semantic-version
           workingDir: $(resources.inputs.app.path)
-          image: gittools/gitversion:5.6.10-alpine.3.12-x64-3.1
+          image: gittools/gitversion:5.8.3-alpine.3.12-5.0-amd64
           imagePullPolicy: IfNotPresent
           resources: {}
           script: |


### PR DESCRIPTION
Make dotnet pipeline use the same GitVersion version as we use in our GH actions for windows builds: https://github.com/saritasa-nest/ccf-ccl-backend/blob/develop/.github/workflows/windows-build.yml#L39

It seems, the current version doesn't always work with .NET 6 projects.