### PR TITLE
feat: add `ignoreDifference` for tekton-apps ArgoCD apps

### DIFF
--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -185,8 +185,8 @@ description: |
       "<apps[PROJECT].kubernetesRepository.url>" or `https://charts.bitnami.com/bitnami` for wordpress projects)
     - apps[PROJECT].components[NAME].argocd.source.targetRevision - tag or branch in the repository for ArgoCD Application (default: kubernetes branch for basic projects
       "<apps[PROJECT].kubernetesRepository.branch>" or "11.0.14" for wordpress projects)
+    - apps[PROJECT].components[NAME].argocd.ignoreDeploymentReplicasDiff - flag whether this exact ArgoCD application should ignore `Replicas` count differences for deployments. It may be needed for `staging` and `prod` environments which use HPA (default: false)
     - apps[PROJECT].components[NAME].applicationURL - url that should be used in tekton build ConfigMap `APPLICATION_URL` param
-    - apps[PROJECT].components[NAME].ignoreDeploymentReplicasDiff - flag whether this exact ArgoCD application should ignore `Replicas` count differences for deployments. It may be needed for `staging` and `prod` environments which use HPA (default: false)
     - apps[PROJECT].components[NAME].tektonKubernetesRepoDeployKeyName - name of existing in kubernetes cluster secret with SSH key to kubernetes repository, used in `kustomize` deployment
       step (i.e. addon-backend-deploy-key). This param sets by default to `<project>-kubernetes-aws-deploy-key` if project has `kubernetesRepository` param in values (actual only for basic
       components, not wordpress)
@@ -606,7 +606,7 @@ description: |
           - CreateNamespace=true
     ```
 
-    If you want to enable ignoring deployment replicas count differences in ArgoCD application of your component add `apps[PROJECT].components[NAME].ignoreDeploymentReplicasDiff: true` flag like in the below example (it may be needed for `staging` and `prod` envs, where you have horizontal pod autoscheduling - HPA):
+    If you want to enable ignoring deployment replicas count differences in ArgoCD application of your component add `apps[PROJECT].components[NAME].argocd.ignoreDeploymentReplicasDiff: true` flag like in the below example (it may be needed for `staging` and `prod` envs, where you have horizontal pod autoscheduling - HPA):
 
     ```yaml
     apiVersion: argoproj.io/v1alpha1
@@ -657,9 +657,10 @@ description: |
                 components:
                   - name: backend
                     repository: xxx-backend
+                    argocd:
+                      ignoreDeploymentReplicasDiff: true
                     pipeline: buildpack-django-build-pipeline
                     applicationURL: https://xxx.site.url
-                    ignoreDeploymentReplicasDiff: true
                     eventlistener:
                       template: buildpack-django-build-pipeline-trigger-template
                       gitWebhookBranches:

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -13,7 +13,7 @@ triggersVersions: "v0.16.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.18
+version: 0.1.19
 
 
 maintainers:

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -186,6 +186,7 @@ description: |
     - apps[PROJECT].components[NAME].argocd.source.targetRevision - tag or branch in the repository for ArgoCD Application (default: kubernetes branch for basic projects
       "<apps[PROJECT].kubernetesRepository.branch>" or "11.0.14" for wordpress projects)
     - apps[PROJECT].components[NAME].applicationURL - url that should be used in tekton build ConfigMap `APPLICATION_URL` param
+    - apps[PROJECT].components[NAME].ignoreDeploymentReplicasDiff - flag whether this exact ArgoCD application should ignore `Replicas` count differences for deployments. It may be needed for `staging` and `prod` environments which use HPA (default: false)
     - apps[PROJECT].components[NAME].tektonKubernetesRepoDeployKeyName - name of existing in kubernetes cluster secret with SSH key to kubernetes repository, used in `kustomize` deployment
       step (i.e. addon-backend-deploy-key). This param sets by default to `<project>-kubernetes-aws-deploy-key` if project has `kubernetesRepository` param in values (actual only for basic
       components, not wordpress)
@@ -583,6 +584,82 @@ description: |
                     repository: xxx-backend
                     pipeline: buildpack-django-build-pipeline
                     applicationURL: https://xxx.site.url
+                    eventlistener:
+                      template: buildpack-django-build-pipeline-trigger-template
+                      gitWebhookBranches:
+                        - develop
+                    triggerBinding:
+                      - name: docker_registry_repository
+                        value: xxx.dkr.ecr.us-west-2.amazonaws.com/xxx/backend
+                      - name: buildpack_builder_image
+                        value: public.ecr.aws/saritasa/buildpacks/google/builder:v1
+                      - name: buildpack_runner_image
+                        value: public.ecr.aws/saritasa/buildpacks/google/runner:v1
+
+        repoURL: https://saritasa-nest.github.io/saritasa-devops-helm-charts/
+        targetRevision: "0.1.16"
+      syncPolicy:
+        automated:
+          prune: true
+          selfHeal: true
+        syncOptions:
+          - CreateNamespace=true
+    ```
+
+    If you want to enable ignoring deployment replicas count differences in ArgoCD application of your component add `apps[PROJECT].components[NAME].ignoreDeploymentReplicasDiff: true` flag like in the below example (it may be needed for `staging` and `prod` envs, where you have horizontal pod autoscheduling - HPA):
+
+    ```yaml
+    apiVersion: argoproj.io/v1alpha1
+    kind: Application
+    metadata:
+      name: tekton-apps
+      namespace: argo-cd
+      finalizers:
+      - resources-finalizer.argocd.argoproj.io
+      annotations:
+        argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
+        argocd.argoproj.io/sync-wave: "41"
+    spec:
+      destination:
+        server: https://kubernetes.default.svc
+        namespace: ci
+      project: default
+      source:
+        chart: saritasa-tekton-apps
+        helm:
+          values: |
+            environment: staging
+            ...
+            apps:
+              - project: xxx-dev
+                environment: dev
+                enabled: true
+                argocd:
+                  labels:
+                    created-by: xxx
+                    ops-main: xxx
+                    ops-secondary: xxx
+                    pm: xxx
+                    tm: xxx
+                  namespace: xxx-dev
+                  extraDestinationNamespaces:
+                    - argo-cd
+                mailList: xxx@saritasa.com
+                devopsMailList: devops+xxx@saritasa.com
+                jiraURL: https://saritasa.atlassian.net/browse/xxx
+                tektonURL: https://tekton.saritasa.rocks/#/namespaces/ci/pipelineruns
+                slack: client-xxx-ci
+                kubernetesRepository:
+                  name: xxx-kubernetes-aws
+                  branch: main
+                  url: git@github.com:saritasa-nest/xxx-kubernetes-aws.git
+
+                components:
+                  - name: backend
+                    repository: xxx-backend
+                    pipeline: buildpack-django-build-pipeline
+                    applicationURL: https://xxx.site.url
+                    ignoreDeploymentReplicasDiff: true
                     eventlistener:
                       template: buildpack-django-build-pipeline-trigger-template
                       gitWebhookBranches:

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 0.1.18](https://img.shields.io/badge/Version-0.1.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.2](https://img.shields.io/badge/AppVersion-v0.28.2-informational?style=flat-square)
+![Version: 0.1.19](https://img.shields.io/badge/Version-0.1.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.2](https://img.shields.io/badge/AppVersion-v0.28.2-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -204,8 +204,8 @@ spec:
     "<apps[PROJECT].kubernetesRepository.url>" or `https://charts.bitnami.com/bitnami` for wordpress projects)
   - apps[PROJECT].components[NAME].argocd.source.targetRevision - tag or branch in the repository for ArgoCD Application (default: kubernetes branch for basic projects
     "<apps[PROJECT].kubernetesRepository.branch>" or "11.0.14" for wordpress projects)
+  - apps[PROJECT].components[NAME].argocd.ignoreDeploymentReplicasDiff - flag whether this exact ArgoCD application should ignore `Replicas` count differences for deployments. It may be needed for `staging` and `prod` environments which use HPA (default: false)
   - apps[PROJECT].components[NAME].applicationURL - url that should be used in tekton build ConfigMap `APPLICATION_URL` param
-  - apps[PROJECT].components[NAME].ignoreDeploymentReplicasDiff - flag whether this exact ArgoCD application should ignore `Replicas` count differences for deployments. It may be needed for `staging` and `prod` environments which use HPA (default: false)
   - apps[PROJECT].components[NAME].tektonKubernetesRepoDeployKeyName - name of existing in kubernetes cluster secret with SSH key to kubernetes repository, used in `kustomize` deployment
     step (i.e. addon-backend-deploy-key). This param sets by default to `<project>-kubernetes-aws-deploy-key` if project has `kubernetesRepository` param in values (actual only for basic
     components, not wordpress)
@@ -624,7 +624,7 @@ spec:
         - CreateNamespace=true
   ```
 
-  If you want to enable ignoring deployment replicas count differences in ArgoCD application of your component add `apps[PROJECT].components[NAME].ignoreDeploymentReplicasDiff: true` flag like in the below example (it may be needed for `staging` and `prod` envs, where you have horizontal pod autoscheduling - HPA):
+  If you want to enable ignoring deployment replicas count differences in ArgoCD application of your component add `apps[PROJECT].components[NAME].argocd.ignoreDeploymentReplicasDiff: true` flag like in the below example (it may be needed for `staging` and `prod` envs, where you have horizontal pod autoscheduling - HPA):
 
   ```yaml
   apiVersion: argoproj.io/v1alpha1
@@ -675,9 +675,10 @@ spec:
               components:
                 - name: backend
                   repository: xxx-backend
+                  argocd:
+                    ignoreDeploymentReplicasDiff: true
                   pipeline: buildpack-django-build-pipeline
                   applicationURL: https://xxx.site.url
-                  ignoreDeploymentReplicasDiff: true
                   eventlistener:
                     template: buildpack-django-build-pipeline-trigger-template
                     gitWebhookBranches:

--- a/charts/tekton-apps/templates/general/argocd_applications.yaml
+++ b/charts/tekton-apps/templates/general/argocd_applications.yaml
@@ -29,7 +29,13 @@ spec:
     path: {{ $argocdSource.path | default (printf "apps/%s/manifests/%s" $component.name $projectEnvironment) }}
     repoURL: {{ $argocdSource.repoUrl | default ($project.kubernetesRepository).url }}
     targetRevision: {{ $argocdSource.targetRevision | default ($project.kubernetesRepository).branch }}
-
+  {{ if (ternary $component.ignoreDeploymentReplicasDiff false (hasKey $component "ignoreDeploymentReplicasDiff")) }}
+  ignoreDifferences:
+  - group: apps
+    kind: Deployment
+    jsonPointers:
+    - /spec/replicas
+  {{- end }}
   syncPolicy:
     automated:
       prune: true

--- a/charts/tekton-apps/templates/general/argocd_applications.yaml
+++ b/charts/tekton-apps/templates/general/argocd_applications.yaml
@@ -29,7 +29,7 @@ spec:
     path: {{ $argocdSource.path | default (printf "apps/%s/manifests/%s" $component.name $projectEnvironment) }}
     repoURL: {{ $argocdSource.repoUrl | default ($project.kubernetesRepository).url }}
     targetRevision: {{ $argocdSource.targetRevision | default ($project.kubernetesRepository).branch }}
-  {{ if (ternary $component.ignoreDeploymentReplicasDiff false (hasKey $component "ignoreDeploymentReplicasDiff")) }}
+  {{ if (ternary $argocd.ignoreDeploymentReplicasDiff false (hasKey $argocd "ignoreDeploymentReplicasDiff")) }}
   ignoreDifferences:
   - group: apps
     kind: Deployment

--- a/charts/tekton-apps/values.yaml
+++ b/charts/tekton-apps/values.yaml
@@ -76,6 +76,7 @@ apps: []
   #       repository: xxx-backend
   #       pipeline: buildpack
   #       applicationURL: https://api.site.com
+  #       ignoreDeploymentReplicasDiff: false
   #       eventlistener:
   #         template: buildpack-backend-build-pipeline-trigger-template
   #       extraBuildConfigParams: # what additional K/V pairs you want to add into the build-pipeline-config configmap
@@ -92,6 +93,7 @@ apps: []
   #       repository: xxx-frontend
   #       pipeline: buildpack
   #       applicationURL: https://site.com
+  #       ignoreDeploymentReplicasDiff: false
   #       eventlistener:
   #         enableWebhookSecret: false
   #         filter: (body.ref.startsWith('refs/heads/develop') || body.ref.startsWith('refs/heads/release/'))

--- a/charts/tekton-apps/values.yaml
+++ b/charts/tekton-apps/values.yaml
@@ -74,9 +74,10 @@ apps: []
   #   components:
   #     - name: backend
   #       repository: xxx-backend
+  #       argocd:
+  #         ignoreDeploymentReplicasDiff: true
   #       pipeline: buildpack
   #       applicationURL: https://api.site.com
-  #       ignoreDeploymentReplicasDiff: false
   #       eventlistener:
   #         template: buildpack-backend-build-pipeline-trigger-template
   #       extraBuildConfigParams: # what additional K/V pairs you want to add into the build-pipeline-config configmap
@@ -91,9 +92,10 @@ apps: []
   #
   #     - name: frontend
   #       repository: xxx-frontend
+  #       argocd:
+  #         ignoreDeploymentReplicasDiff: true
   #       pipeline: buildpack
   #       applicationURL: https://site.com
-  #       ignoreDeploymentReplicasDiff: false
   #       eventlistener:
   #         enableWebhookSecret: false
   #         filter: (body.ref.startsWith('refs/heads/develop') || body.ref.startsWith('refs/heads/release/'))


### PR DESCRIPTION
Add possibility to ignore deployment replica sets differences in ArgoCD applications. It is needed for HPA in staging and prod K8S clusters.

Added new parameter to components:

```
  apiVersion: argoproj.io/v1alpha1
  kind: Application
  metadata:
    name: tekton-apps
    namespace: argo-cd
    finalizers:
    - resources-finalizer.argocd.argoproj.io
    annotations:
      argocd.argoproj.io/sync-options: SkipDryRunOnMissingResource=true
      argocd.argoproj.io/sync-wave: "41"
  spec:
    destination:
      server: https://kubernetes.default.svc
      namespace: ci
    project: default
    source:
      chart: saritasa-tekton-apps
      helm:
        values: |
          environment: staging
          ...
          apps:
            - project: xxx-dev
              environment: dev
              enabled: true
              argocd:
                labels:
                  created-by: xxx
                  ops-main: xxx
                  ops-secondary: xxx
                  pm: xxx
                  tm: xxx
                namespace: xxx-dev
                extraDestinationNamespaces:
                  - argo-cd
              mailList: xxx@saritasa.com
              devopsMailList: devops+xxx@saritasa.com
              jiraURL: https://saritasa.atlassian.net/browse/xxx
              tektonURL: https://tekton.saritasa.rocks/#/namespaces/ci/pipelineruns
              slack: client-xxx-ci
              kubernetesRepository:
                name: xxx-kubernetes-aws
                branch: main
                url: git@github.com:saritasa-nest/xxx-kubernetes-aws.git

              components:
                - name: backend
                  repository: xxx-backend
                  argocd:
                      ignoreDeploymentReplicasDiff: true  <------------------------------------------------
                  pipeline: buildpack-django-build-pipeline
                  applicationURL: https://xxx.site.url
                  eventlistener:
                    template: buildpack-django-build-pipeline-trigger-template
                    gitWebhookBranches:
                      - develop
                  triggerBinding:
                    - name: docker_registry_repository
                      value: xxx.dkr.ecr.us-west-2.amazonaws.com/xxx/backend
                    - name: buildpack_builder_image
                      value: public.ecr.aws/saritasa/buildpacks/google/builder:v1
                    - name: buildpack_runner_image
                      value: public.ecr.aws/saritasa/buildpacks/google/runner:v1

      repoURL: https://saritasa-nest.github.io/saritasa-devops-helm-charts/
      targetRevision: "0.1.16"
    syncPolicy:
      automated:
        prune: true
        selfHeal: true
      syncOptions:
        - CreateNamespace=true
```
