### PR TITLE
feature/improve argocd deploy task

### DIFF
--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.23
+version: 0.1.24
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.25
+version: 0.1.26
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.24
+version: 0.1.25
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 0.1.24](https://img.shields.io/badge/Version-0.1.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.25](https://img.shields.io/badge/Version-0.1.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 0.1.25](https://img.shields.io/badge/Version-0.1.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.26](https://img.shields.io/badge/Version-0.1.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 
@@ -176,7 +176,6 @@ to specific project trigger-binding:
 | buildpacks.generate.buildpackRubyBuildPipeline.name | string | `"buildpack-ruby-build-pipeline"` | the name of the generated pipeline |
 | imagePullPolicy | string | `"IfNotPresent"` | default imagePullPolicy to be used for images pulled in tekton task steps |
 | images | object | See below | default images used in our solution |
-| images.argocd | string | `"argoproj/argocd:v2.3.4"` | argocd image (used in argocd-deploy task) |
 | images.argocd_cli | string | `"https://github.com/argoproj/argo-cd/releases/download/v2.3.4/argocd-linux-amd64"` | argocd cli downdload URL |
 | images.awscli | string | `"docker.io/amazon/aws-cli:2.7.4"` | aws cli image (used for aws ecr auth) |
 | images.bash | string | `"docker.io/library/bash:5.1.8"` | bash image (used for various ops in steps) |

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 0.1.23](https://img.shields.io/badge/Version-0.1.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.24](https://img.shields.io/badge/Version-0.1.24-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 
@@ -176,7 +176,8 @@ to specific project trigger-binding:
 | buildpacks.generate.buildpackRubyBuildPipeline.name | string | `"buildpack-ruby-build-pipeline"` | the name of the generated pipeline |
 | imagePullPolicy | string | `"IfNotPresent"` | default imagePullPolicy to be used for images pulled in tekton task steps |
 | images | object | See below | default images used in our solution |
-| images.argocd | string | `"argoproj/argocd:v2.3.4"` | argocd cli image (used in argocd-deploy task) |
+| images.argocd | string | `"argoproj/argocd:v2.3.4"` | argocd image (used in argocd-deploy task) |
+| images.argocd_cli | string | `"https://github.com/argoproj/argo-cd/releases/download/v2.3.4/argocd-linux-amd64"` | argocd cli downdload URL |
 | images.awscli | string | `"docker.io/amazon/aws-cli:2.7.4"` | aws cli image (used for aws ecr auth) |
 | images.bash | string | `"docker.io/library/bash:5.1.8"` | bash image (used for various ops in steps) |
 | images.git | string | `"alpine/git:v2.32.0"` | git image |

--- a/charts/tekton-pipelines/templates/common/tasks/argocd-deploy.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/argocd-deploy.yaml
@@ -27,27 +27,28 @@ spec:
       script: |
         #!/usr/bin/env bash
         set +x
-        curl --silent -o /usr/local/bin/argocd {{ .Values.images.argocd_cli }}
+        curl --silent --location -o /usr/local/bin/argocd {{ .Values.images.argocd_cli }}
+        chmod +x /usr/local/bin/argocd
 
         # connect to private service
         # instead of connecting through a public ingress
-        echo "login to argocd"
-        yes | argocd login \
-          --insecure argo-cd-argocd-server.argo-cd \
+        yes | argocd login argo-cd-argocd-server.argo-cd \
+          --insecure \
           --grpc-web \
           --grpc-web-root-path $ARGOCD_ROOT_PATH \
           --username $ARGOCD_USERNAME \
           --password $ARGOCD_PASSWORD \
           --http-retry-max 3
 
-        echo "app sync $(params.application)"
-        argocd app sync $(params.application)
+        argocd app sync $(params.application) \
+          --server=argo-cd-argocd-server.argo-cd
 
         argocd app wait $(params.application) \
+          --server=argo-cd-argocd-server.argo-cd \
           --health=true \
           --operation=true
 
-        synced=`argocd app get $(params.application) -o json | jq -r '.status.sync.status' | awk '{print tolower($1)}'`
-        healthy=`argocd app get $(params.application) -o json | jq -r '.status.health.status' | awk '{print tolower($1)}'`
+        synced=`argocd app get $(params.application) --server=argo-cd-argocd-server.argo-cd -o json | jq -r '.status.sync.status' | awk '{print tolower($1)}'`
+        healthy=`argocd app get $(params.application) --server=argo-cd-argocd-server.argo-cd -o json | jq -r '.status.health.status' | awk '{print tolower($1)}'`
 
         [[ "$synced" == "synced" ]] && [[ "$healthy" == "healthy" ]] && echo "Sync completed succcessfully. App is healthy!" || (echo "Sync failed" && exit 1)

--- a/charts/tekton-pipelines/templates/common/tasks/argocd-deploy.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/argocd-deploy.yaml
@@ -22,30 +22,32 @@ spec:
           name: $(params.application)-argocd-secret  # used for authentication (username/password or auth token)
   steps:
     - name: deploy
-      image: {{ .Values.images.argocd | default "argoproj/argocd:latest" }}
+      image: cfmanteiga/alpine-bash-curl-jq
       imagePullPolicy: {{ .Values.imagePullPolicy }}
       script: |
-        #!/bin/bash
-        argocd login $ARGOCD_SERVER \
+        #!/usr/bin/env bash
+        set +x
+        curl --silent -o /usr/local/bin/argocd {{ .Values.images.argocd_cli }}
+
+        # connect to private service
+        # instead of connecting through a public ingress
+        echo "login to argocd"
+        yes | argocd login \
+          --insecure argo-cd-argocd-server.argo-cd \
           --grpc-web \
           --grpc-web-root-path $ARGOCD_ROOT_PATH \
           --username $ARGOCD_USERNAME \
           --password $ARGOCD_PASSWORD \
           --http-retry-max 3
 
-        argocd app sync $(params.application) \
-          --grpc-web \
-          --grpc-web-root-path $ARGOCD_ROOT_PATH \
-          --server $ARGOCD_SERVER
+        echo "app sync $(params.application)"
+        argocd app sync $(params.application)
 
         argocd app wait $(params.application) \
           --health=true \
-          --operation=true \
-          --grpc-web \
-          --grpc-web-root-path $ARGOCD_ROOT_PATH \
-          --server $ARGOCD_SERVER
+          --operation=true
 
-        synced=`argocd app get $(params.application) | grep "Sync Status:" | awk '{print tolower($3)}'`
-        healthy=`argocd app get $(params.application) | grep "Health Status:" | awk '{print tolower($3)}'`
-        [[ "$synced" == "synced" ]] && [[ "$healthy" == "healthy" ]] \
-           && echo "Sync completed succcessfully. App is healthy!" || (echo "Sync failed" && exit 1)
+        synced=`argocd app get $(params.application) -o json | jq -r '.status.sync.status' | awk '{print tolower($1)}'`
+        healthy=`argocd app get $(params.application) -o json | jq -r '.status.health.status' | awk '{print tolower($1)}'`
+
+        [[ "$synced" == "synced" ]] && [[ "$healthy" == "healthy" ]] && echo "Sync completed succcessfully. App is healthy!" || (echo "Sync failed" && exit 1)

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -5,8 +5,10 @@
 # -- default images used in our solution
 # @default -- See below
 images:
-  # -- argocd cli image (used in argocd-deploy task)
+  # -- argocd image (used in argocd-deploy task)
   argocd:    argoproj/argocd:v2.3.4
+  # -- argocd cli downdload URL
+  argocd_cli: https://github.com/argoproj/argo-cd/releases/download/v2.3.4/argocd-linux-amd64
   # -- bash image (used for various ops in steps)
   bash:      docker.io/library/bash:5.1.8
   # -- aws cli image (used for aws ecr auth)

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -5,8 +5,6 @@
 # -- default images used in our solution
 # @default -- See below
 images:
-  # -- argocd image (used in argocd-deploy task)
-  argocd:    argoproj/argocd:v2.3.4
   # -- argocd cli downdload URL
   argocd_cli: https://github.com/argoproj/argo-cd/releases/download/v2.3.4/argocd-linux-amd64
   # -- bash image (used for various ops in steps)


### PR DESCRIPTION
- remove argocd image from argocd-deploy task as it's 600mb, converted to pure bash + curl
- used internal service connection for argocd as we had some issues with going over external ingress resulting in timeouts (only with karpenter provisioned nodes, we had no such issue with managed eks nodes. This requre additional investigation)

Overall we saved around 35-40s from pipelinerun execution by doing these steps.