### PR TITLE
feat: add kuberntest maintenance page helm chart

### DIFF
--- a/charts/maintenance-page/.helmignore
+++ b/charts/maintenance-page/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/maintenance-page/Chart.yaml
+++ b/charts/maintenance-page/Chart.yaml
@@ -17,3 +17,25 @@ description: |
   A Helm chart for Kubernetes to display a simple maintenance page.
   By default it displays the following content:
   [https://codepen.io/dmitry-mightydevops/pen/poLaZqO](https://codepen.io/dmitry-mightydevops/pen/poLaZqO)
+
+  You can adjust the look by setting up the following values in the values.yaml file:
+
+
+  ```yaml
+  message:
+    backgroundColor: "#d6433b"
+    textColor: "#fff"
+    title: "Site Maintenance"
+    header: "We&rsquo;ll be back soon!"
+    body: |
+      <p>Sorry for the inconvenience. We&rsquo;re performing some maintenance at the moment. We&rsquo;ll be back up shortly!</p>
+    footer: |
+      <p>&mdash; The DevOps Team</p>
+  ```
+
+  or by supplying an entire HTML for the maintenance page via
+
+  ```yaml
+  html: |
+    hello, the maintenance page HTML + CSS code is here
+  ```

--- a/charts/maintenance-page/Chart.yaml
+++ b/charts/maintenance-page/Chart.yaml
@@ -1,0 +1,19 @@
+apiVersion: v2
+name: maintenance-page
+
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+maintainers:
+  - url: https://www.saritasa.com/
+    name: Saritasa
+    email: nospam@saritasa.com
+
+description: |
+  A Helm chart for Kubernetes to display a simple maintenance page.
+  By default it displays the following content:
+  [https://codepen.io/dmitry-mightydevops/pen/poLaZqO](https://codepen.io/dmitry-mightydevops/pen/poLaZqO)

--- a/charts/maintenance-page/Chart.yaml
+++ b/charts/maintenance-page/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/maintenance-page/README.md
+++ b/charts/maintenance-page/README.md
@@ -31,7 +31,7 @@ maintenance-page
 
 ## `chart.version`
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/maintenance-page/README.md
+++ b/charts/maintenance-page/README.md
@@ -50,7 +50,7 @@ By default it displays the following content:
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
 | affinity | object | `{}` |  |
-| environment | string | `"staging"` | name of the environment you're placing the maintenance page for like dev, prod, staging |
+| environment | string | `""` | name of the environment you're placing the maintenance page for like dev, prod, staging |
 | fullnameOverride | string | `""` |  |
 | html | string | `""` | html for the maintenance page. If you need a totally custom HTML design, then keep message config above empty and put here a full HTML (CSS+HTML). You can test the page here: https://codepen.io/dmitry-mightydevops/pen/poLaZqO |
 | image.pullPolicy | string | `"IfNotPresent"` | pull policy |

--- a/charts/maintenance-page/README.md
+++ b/charts/maintenance-page/README.md
@@ -1,0 +1,78 @@
+
+# maintenance-page
+
+## `license`
+```
+          ,-.
+ ,     ,-.   ,-.
+/ \   (   )-(   )
+\ |  ,.>-(   )-<
+ \|,' (   )-(   )
+  Y ___`-'   `-'
+  |/__/   `-'
+  |
+  |
+  |    -hi-
+__|_____________
+
+/* Copyright (C) Saritasa,LLC - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Written by Saritasa Devops Team, April 2022
+ */
+
+```
+
+## `chart.deprecationWarning`
+
+## `chart.name`
+
+maintenance-page
+
+## `chart.version`
+
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Saritasa | <nospam@saritasa.com> | <https://www.saritasa.com/> |
+
+## `chart.description`
+
+A Helm chart for Kubernetes to display a simple maintenance page.
+By default it displays the following content:
+[https://codepen.io/dmitry-mightydevops/pen/poLaZqO](https://codepen.io/dmitry-mightydevops/pen/poLaZqO)
+
+## `chart.valuesTable`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| affinity | object | `{}` |  |
+| environment | string | `"staging"` | name of the environment you're placing the maintenance page for like dev, prod, staging |
+| fullnameOverride | string | `""` |  |
+| html | string | `""` | html for the maintenance page. If you need a totally custom HTML design, then keep message config above empty and put here a full HTML (CSS+HTML). You can test the page here: https://codepen.io/dmitry-mightydevops/pen/poLaZqO |
+| image.pullPolicy | string | `"IfNotPresent"` | pull policy |
+| image.repository | string | `"saritasallc/kubernetes-maintenance-page"` | container repository |
+| image.tag | string | `"0.1"` | Overrides the image tag whose default is the chart appVersion. |
+| imagePullSecrets | list | `[]` | credentials for docker login |
+| message | object | `{}` | message configuration in the maintenance page. |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| podAnnotations | object | `{}` |  |
+| podSecurityContext | object | `{}` |  |
+| replicaCount | int | `1` | how many replicas (pods) to run |
+| resources.limits.cpu | string | `"100m"` |  |
+| resources.limits.memory | string | `"128Mi"` |  |
+| resources.requests.cpu | string | `"50m"` |  |
+| resources.requests.memory | string | `"50Mi"` |  |
+| securityContext.runAsNonRoot | bool | `true` | run the container as non-root user |
+| securityContext.runAsUser | int | `101` | run under non-root user, 101 - is nginx user defined in the docker container |
+| service.port | int | `8080` |  |
+| service.type | string | `"ClusterIP"` |  |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| tolerations | list | `[]` |  |
+

--- a/charts/maintenance-page/README.md
+++ b/charts/maintenance-page/README.md
@@ -45,6 +45,27 @@ A Helm chart for Kubernetes to display a simple maintenance page.
 By default it displays the following content:
 [https://codepen.io/dmitry-mightydevops/pen/poLaZqO](https://codepen.io/dmitry-mightydevops/pen/poLaZqO)
 
+You can adjust the look by setting up the following values in the values.yaml file:
+
+```yaml
+message:
+  backgroundColor: "#d6433b"
+  textColor: "#fff"
+  title: "Site Maintenance"
+  header: "We&rsquo;ll be back soon!"
+  body: |
+    <p>Sorry for the inconvenience. We&rsquo;re performing some maintenance at the moment. We&rsquo;ll be back up shortly!</p>
+  footer: |
+    <p>&mdash; The DevOps Team</p>
+```
+
+or by supplying an entire HTML for the maintenance page via
+
+```yaml
+html: |
+  hello, the maintenance page HTML + CSS code is here
+```
+
 ## `chart.valuesTable`
 
 | Key | Type | Default | Description |
@@ -54,7 +75,7 @@ By default it displays the following content:
 | fullnameOverride | string | `""` |  |
 | html | string | `""` | html for the maintenance page. If you need a totally custom HTML design, then keep message config above empty and put here a full HTML (CSS+HTML). You can test the page here: https://codepen.io/dmitry-mightydevops/pen/poLaZqO |
 | image.pullPolicy | string | `"IfNotPresent"` | pull policy |
-| image.repository | string | `"saritasallc/kubernetes-maintenance-page"` | container repository |
+| image.repository | string | `"saritasallc/kubernetes-maintenance-page"` | container repository, adjust in https://github.com/saritasa-nest/saritasa-devops-docker-images/pull/29 |
 | image.tag | string | `"0.1"` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | credentials for docker login |
 | message | object | `{}` | message configuration in the maintenance page. |

--- a/charts/maintenance-page/README.md.gotmpl
+++ b/charts/maintenance-page/README.md.gotmpl
@@ -1,0 +1,27 @@
+{{ template "chart.header" . }}
+
+## `license`
+{{ template "license" . }}
+
+## `chart.deprecationWarning`
+{{ template "chart.deprecationWarning" . }}
+
+## `chart.name`
+
+{{ template "chart.name" . }}
+
+## `chart.version`
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+## `chart.description`
+
+{{ template "chart.description" . }}
+
+## `chart.valuesTable`
+
+{{ template "chart.valuesTable" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/maintenance-page/templates/_helpers.tpl
+++ b/charts/maintenance-page/templates/_helpers.tpl
@@ -11,11 +11,12 @@ We truncate at 63 chars because some Kubernetes name fields are limited to this 
 If release name contains chart name it will be used as a full name.
 */}}
 {{- define "maintenance-page.fullname" -}}
-{{- if .Values.environment }}
+{{- if .Values.fullnameOverride  }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else if .Values.environment }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
 {{- printf "%s-%s" .Values.environment $name | trunc 63 | trimSuffix "-" }}
-{{- else if .Values.fullnameOverride }}
-{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
 {{- else }}
 {{- $name := default .Chart.Name .Values.nameOverride }}
 {{- if contains $name .Release.Name }}

--- a/charts/maintenance-page/templates/_helpers.tpl
+++ b/charts/maintenance-page/templates/_helpers.tpl
@@ -1,0 +1,66 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "maintenance-page.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "maintenance-page.fullname" -}}
+{{- if .Values.environment }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- printf "%s-%s" .Values.environment $name | trunc 63 | trimSuffix "-" }}
+{{- else if .Values.fullnameOverride }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "maintenance-page.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "maintenance-page.labels" -}}
+helm.sh/chart: {{ include "maintenance-page.chart" . }}
+{{ include "maintenance-page.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "maintenance-page.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "maintenance-page.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+maintenance: 'true'
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "maintenance-page.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "maintenance-page.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}

--- a/charts/maintenance-page/templates/configmap.yaml
+++ b/charts/maintenance-page/templates/configmap.yaml
@@ -5,7 +5,7 @@ metadata:
 data:
   index.html: |
     {{- if .Values.html }}
-    {{ .Values.html }}
+    {{- .Values.html | nindent 4 }}
     {{- else }}
     <!doctype html>
     <title>{{ .Values.message.title  | default "Site Maintenance" }}</title>

--- a/charts/maintenance-page/templates/configmap.yaml
+++ b/charts/maintenance-page/templates/configmap.yaml
@@ -1,0 +1,104 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "maintenance-page.fullname" . }}
+data:
+  index.html: |
+    {{- if .Values.html }}
+    {{ .Values.html }}
+    {{- else }}
+    <!doctype html>
+    <title>{{ .Values.message.title  | default "Site Maintenance" }}</title>
+    <link href="https://fonts.googleapis.com/css?family=Open+Sans:300,400,700" rel="stylesheet">
+    <style>
+            html,
+            body {
+                    padding: 0;
+                    margin: 0;
+                    width: 100%;
+                    height: 100%;
+            }
+
+            * {
+                    box-sizing: border-box;
+            }
+
+            body {
+                    text-align: center;
+                    padding: 0;
+                    background: {{ .Values.message.backgroundColor | default "#d6433b" }};
+                    color: {{ .Values.message.textColor | default "#fff" }};
+                    font-family: Open Sans;
+            }
+
+            h1 {
+                    font-size: 50px;
+                    font-weight: 100;
+                    text-align: center;
+            }
+
+            body {
+                    font-family: Open Sans;
+                    font-weight: 100;
+                    font-size: 20px;
+                    color: {{ .Values.message.textColor | default "#fff" }};
+                    text-align: center;
+                    display: -webkit-box;
+                    display: -ms-flexbox;
+                    display: flex;
+                    -webkit-box-pack: center;
+                    -ms-flex-pack: center;
+                    justify-content: center;
+                    -webkit-box-align: center;
+                    -ms-flex-align: center;
+                    align-items: center;
+            }
+
+            article {
+                    display: block;
+                    width: 700px;
+                    padding: 50px;
+                    margin: 0 auto;
+            }
+
+            a {
+                    color: #fff;
+                    font-weight: bold;
+            }
+
+            a:hover {
+                    text-decoration: none;
+            }
+
+            svg {
+                    width: 75px;
+                    margin-top: 1em;
+            }
+    </style>
+
+    <article>
+            <svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 202.24 202.24">
+                    <defs>
+                            <style>
+                                    .cls-1 {
+                                            fill: #fff;
+                                    }
+                            </style>
+                    </defs>
+                    <title>Asset 3</title>
+                    <g id="Layer_2" data-name="Layer 2">
+                            <g id="Capa_1" data-name="Capa 1">
+                                    <path class="cls-1"
+                                            d="M101.12,0A101.12,101.12,0,1,0,202.24,101.12,101.12,101.12,0,0,0,101.12,0ZM159,148.76H43.28a11.57,11.57,0,0,1-10-17.34L91.09,31.16a11.57,11.57,0,0,1,20.06,0L169,131.43a11.57,11.57,0,0,1-10,17.34Z" />
+                                    <path class="cls-1"
+                                            d="M101.12,36.93h0L43.27,137.21H159L101.13,36.94Zm0,88.7a7.71,7.71,0,1,1,7.71-7.71A7.71,7.71,0,0,1,101.12,125.63Zm7.71-50.13a7.56,7.56,0,0,1-.11,1.3l-3.8,22.49a3.86,3.86,0,0,1-7.61,0l-3.8-22.49a8,8,0,0,1-.11-1.3,7.71,7.71,0,1,1,15.43,0Z" />
+                            </g>
+                    </g>
+            </svg>
+            <h1>{{ .Values.message.header  | default "We&rsquo;ll be back soon!" }}</h1>
+            <div>
+                {{ .Values.message.body   | default "<p>Sorry for the inconvenience. We&rsquo;re performing some maintenance at the moment. We&rsquo;ll be back up shortly!</p>" }}
+                {{ .Values.message.footer | default "<p>&mdash; The DevOps Team</p>" }}
+            </div>
+    </article>
+    {{- end }}

--- a/charts/maintenance-page/templates/deployment.yaml
+++ b/charts/maintenance-page/templates/deployment.yaml
@@ -1,0 +1,69 @@
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: {{ include "maintenance-page.fullname" . }}
+  labels:
+    {{- include "maintenance-page.labels" . | nindent 4 }}
+spec:
+  replicas: {{ .Values.replicaCount }}
+  selector:
+    matchLabels:
+      {{- include "maintenance-page.selectorLabels" . | nindent 6 }}
+  template:
+    metadata:
+      {{- with .Values.podAnnotations }}
+      annotations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      labels:
+        {{- include "maintenance-page.selectorLabels" . | nindent 8 }}
+    spec:
+      {{- with .Values.imagePullSecrets }}
+      imagePullSecrets:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      serviceAccountName: {{ include "maintenance-page.serviceAccountName" . }}
+      securityContext:
+        {{- toYaml .Values.podSecurityContext | nindent 8 }}
+      containers:
+        - name: {{ .Chart.Name }}
+          securityContext:
+            {{- toYaml .Values.securityContext | nindent 12 }}
+          image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+          imagePullPolicy: {{ .Values.image.pullPolicy }}
+          ports:
+            - name: http
+              containerPort: 8080
+              protocol: TCP
+          livenessProbe:
+            httpGet:
+              path: /
+              port: http
+          readinessProbe:
+            httpGet:
+              path: /
+              port: http
+          resources:
+            {{- toYaml .Values.resources | nindent 12 }}
+
+          volumeMounts:
+            - name: index-page
+              mountPath: /app/index.html
+              subPath: index.html
+      volumes:
+        - name: index-page
+          configMap:
+            name: {{ include "maintenance-page.fullname" . }}
+
+      {{- with .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.affinity }}
+      affinity:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.tolerations }}
+      tolerations:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}

--- a/charts/maintenance-page/templates/service.yaml
+++ b/charts/maintenance-page/templates/service.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: Service
+metadata:
+  name: {{ include "maintenance-page.fullname" . }}
+  labels:
+    {{- include "maintenance-page.labels" . | nindent 4 }}
+spec:
+  type: {{ .Values.service.type }}
+  ports:
+    - port: {{ .Values.service.port }}
+      targetPort: http
+      protocol: TCP
+      name: http
+  selector:
+    {{- include "maintenance-page.selectorLabels" . | nindent 4 }}

--- a/charts/maintenance-page/templates/serviceaccount.yaml
+++ b/charts/maintenance-page/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "maintenance-page.serviceAccountName" . }}
+  labels:
+    {{- include "maintenance-page.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/maintenance-page/values.yaml
+++ b/charts/maintenance-page/values.yaml
@@ -1,0 +1,71 @@
+# Default values for maintenance-page.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+# -- how many replicas (pods) to run
+replicaCount: 1
+
+image:
+  # -- container repository
+  repository: saritasallc/kubernetes-maintenance-page
+  # -- pull policy
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: "0.1"
+
+# -- name of the environment you're placing the maintenance page for like dev, prod, staging
+environment: "staging"
+# -- message configuration in the maintenance page.
+message: {}
+  # backgroundColor: "#d6433b"
+  # textColor: "#fff"
+  # title: "Site Maintenance"
+  # header: "We&rsquo;ll be back soon!"
+  # body: |
+  #   <p>Sorry for the inconvenience. We&rsquo;re performing some maintenance at the moment. We&rsquo;ll be back up shortly!</p>
+  # footer: |
+  #   <p>&mdash; The DevOps Team</p>
+
+# -- html for the maintenance page. If you need a totally custom HTML design, then keep message config above empty and put here a full HTML (CSS+HTML). You can test the page here: https://codepen.io/dmitry-mightydevops/pen/poLaZqO
+html: |
+
+# -- credentials for docker login
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use. If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+podAnnotations: {}
+
+podSecurityContext: {}
+
+securityContext:
+  # -- run the container as non-root user
+  runAsNonRoot: true
+  # -- run under non-root user, 101 - is nginx user defined in the docker container
+  runAsUser: 101
+
+service:
+  type: ClusterIP
+  port: 8080
+
+resources:
+  limits:
+    cpu: 100m
+    memory: 128Mi
+  requests:
+    cpu: 50m
+    memory: 50Mi
+
+nodeSelector: {}
+
+tolerations: []
+
+affinity: {}

--- a/charts/maintenance-page/values.yaml
+++ b/charts/maintenance-page/values.yaml
@@ -6,7 +6,7 @@
 replicaCount: 1
 
 image:
-  # -- container repository
+  # -- container repository, adjust in https://github.com/saritasa-nest/saritasa-devops-docker-images/pull/29
   repository: saritasallc/kubernetes-maintenance-page
   # -- pull policy
   pullPolicy: IfNotPresent

--- a/charts/maintenance-page/values.yaml
+++ b/charts/maintenance-page/values.yaml
@@ -14,7 +14,7 @@ image:
   tag: "0.1"
 
 # -- name of the environment you're placing the maintenance page for like dev, prod, staging
-environment: "staging"
+environment: ""
 # -- message configuration in the maintenance page.
 message: {}
   # backgroundColor: "#d6433b"


### PR DESCRIPTION
display maintenance page inside kubernetes cluster
uses this docker image: https://github.com/saritasa-nest/saritasa-devops-docker-images/pull/29

See it in action:
https://player.vimeo.com/video/736346976?h=1d7685f9d6&amp;badge=0&amp;autopause=0&amp;player_id=0&amp;app_id=58479