### PR TITLE
feat: upgrade wordpress version

### DIFF
--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -13,7 +13,7 @@ triggersVersions: "v0.16.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.20
+version: 0.1.21
 
 
 maintainers:

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 0.1.20](https://img.shields.io/badge/Version-0.1.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.2](https://img.shields.io/badge/AppVersion-v0.28.2-informational?style=flat-square)
+![Version: 0.1.21](https://img.shields.io/badge/Version-0.1.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.2](https://img.shields.io/badge/AppVersion-v0.28.2-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-apps/templates/wordpress/argocd_applications.yaml
+++ b/charts/tekton-apps/templates/wordpress/argocd_applications.yaml
@@ -250,7 +250,7 @@ spec:
         {{- toYaml $component.wordpress.extraEnvVars | nindent 10 }}
         {{- end }}
     repoURL: {{ $argocdSource.repoUrl | default "https://charts.bitnami.com/bitnami" }}
-    targetRevision: {{ $argocdSource.targetRevision | default "11.0.14" }}
+    targetRevision: {{ $argocdSource.targetRevision | default "15.0.16" }}
 
   syncPolicy:
     automated:


### PR DESCRIPTION
I also updated values.yaml in rocks to include these versions for all WP components
```yaml
components: 
  - name: wordpress
    repository: augcard-wordpress
    pipeline: wordpress-build-pipeline
    applicationURL: https://augcard.saritasa.rocks
    argocd:
      source:
        targetRevision: 15.0.16
    wordpress:
      imageTag: 6.0.1-debian-11-r12
      resources:
```

updated wordpresses:

- https://bollards.saritasa.rocks/
- https://augcard.saritasa.rocks/
- https://haulink-wp.saritasa.rocks/
- https://blog.interesnee.saritasa.rocks/
- https://wordpress.demo.saritasa.rocks/
- https://taco.saritasa.rocks/
- https://webrefresh.technoir.saritasa.rocks/
- https://poc.zincasa.saritasa.rocks/
- https://webrefresh.technoir.saritasa.rocks/