### PR TITLE
feat: add `repository_submodules` flag to enable/disable loading submodules, add dotnet step to ignore `*.dcproj` files

### DIFF
--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -13,7 +13,7 @@ triggersVersions: "v0.16.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.22
+version: 0.1.23-dev
 
 
 maintainers:

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -13,7 +13,7 @@ triggersVersions: "v0.16.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.24-dev
+version: 0.1.24
 
 
 maintainers:

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -13,7 +13,7 @@ triggersVersions: "v0.16.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.23-dev
+version: 0.1.24-dev
 
 
 maintainers:
@@ -205,9 +205,25 @@ description: |
     into the generated triggerbinding associated with your app. However the chart renders some default values based on the values
     in this values.yaml file:
 
-      - application, project, environment, docker_registry, kubernetes_repository_ssh_url, kubernetes_branch, kubernetes_repository_kustomize_path, source_subpath (for basic components)
+      - application, project, environment, docker_registry, kubernetes_repository_ssh_url, kubernetes_branch, kubernetes_repository_kustomize_path, source_subpath, repository_submodules (for basic components)
       - application, project, environment, namespace (for wordpress components)
 
+    Note: sometimes github repository may contain another github repositories as submodules. These github `submodules` may be public or private. In case of private submodules usage there is a necessity to add 
+    separate submodules private repos `deploy-keys` to be able to pull them within Tekton build. Currently this feature to pull private github submodules during build doesn't work. So there is added workaround
+    for this problem - you can pass `repository_submodules: false` value and it will omit github submodules upload during build process (default value for `repository_submodules` is true, so we try to load 
+    repo submodules by default). Example:
+
+    ```yaml
+    apps:
+      - project: xxx
+        ... 
+        components:
+          - name: backend
+            ...
+            triggerBinding:
+              - name: repository_submodules
+                value: false
+    ```
 
     # fill below parameters block only for `wordpress` components
 

--- a/charts/tekton-apps/templates/general/triggerbindings.yaml
+++ b/charts/tekton-apps/templates/general/triggerbindings.yaml
@@ -33,6 +33,8 @@ spec:
     value: {{ $project.project }}
   - name: component
     value: {{ $component.name }}
+  - name: repository_submodules
+    value: "{{ $component.repository_submodules | default true }}"
   {{- include "tekton-apps.get-triggerbinding-value-or-default" (dict "triggerBinding" $component.triggerBinding "name" "environment" "default" $projectEnvironment ) | nindent 2 }}
   {{- if $.Values.defaultRegistry }}
   - name: docker_registry

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.28-dev
+version: 0.1.28
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.27
+version: 0.1.28-dev
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/templates/_snippets.tpl
+++ b/charts/tekton-pipelines/templates/_snippets.tpl
@@ -192,6 +192,8 @@
         value: $(tt.params.repository_ssh_url)
       - name: revision
         value: $(tt.params.head_commit)
+      - name: submodules
+        value: $(tt.params.repository_submodules)
 - name: kubernetes-repo
   resourceSpec:
     type: git

--- a/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
@@ -12,6 +12,10 @@ spec:
     {{ include "pipeline.defaultParams" . | nindent 4 }}
     {{ include "pipeline.defaultDockerKubernetesParams" . | nindent 4 }}
 
+    - name: repository_submodules
+      description: defines whether repository should be initialized with submodules
+      default: "true"
+
     - name: buildpack_builder_image
       type: string
       description: the image on which builds will run (must include lifecycle and compatible buildpacks).

--- a/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
@@ -13,7 +13,7 @@ spec:
     {{ include "pipeline.defaultDockerKubernetesParams" . | nindent 4 }}
 
     - name: repository_submodules
-      description: defines whether repository should be initialized with submodules
+      description: defines whether repository should be initialized with submodules or not (if false value is set, it means no repository submodules would be downloaded)
       default: "true"
 
     - name: buildpack_builder_image

--- a/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
@@ -17,6 +17,10 @@ spec:
 
     - name: repository_ssh_url
       description: git repository ssh url
+    
+    - name: repository_submodules
+      description: defines whether repository should be initialized with submodules
+      default: "true"
 
     - name: kubernetes_repository_ssh_url
       description: git repository ssh url for kubernetes manifests repo
@@ -57,6 +61,8 @@ spec:
           value: "$(tt.params.buildpack_runner_image)"
         - name: source_subpath
           value: "$(tt.params.source_subpath)"
+        - name: repository_submodules
+          value: "$(tt.params.repository_submodules)"
 
       resources:
         {{- include "pipeline.defaultResources" . | nindent 8 }}

--- a/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
@@ -19,7 +19,7 @@ spec:
       description: git repository ssh url
     
     - name: repository_submodules
-      description: defines whether repository should be initialized with submodules
+      description: defines whether repository should be initialized with submodules or not (if false value is set, it means no repository submodules would be downloaded)
       default: "true"
 
     - name: kubernetes_repository_ssh_url

--- a/charts/tekton-pipelines/templates/kaniko/trigger-template.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/trigger-template.yaml
@@ -13,7 +13,7 @@ spec:
       description: git repository ssh url
 
     - name: repository_submodules
-      description: defines whether repository should be initialized with submodules
+      description: defines whether repository should be initialized with submodules or not (if false value is set, it means no repository submodules would be downloaded)
       default: "true"
 
     - name: kubernetes_repository_ssh_url

--- a/charts/tekton-pipelines/templates/kaniko/trigger-template.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/trigger-template.yaml
@@ -12,6 +12,10 @@ spec:
     - name: repository_ssh_url
       description: git repository ssh url
 
+    - name: repository_submodules
+      description: defines whether repository should be initialized with submodules
+      default: "true"
+
     - name: kubernetes_repository_ssh_url
       description: git repository ssh url for kubernetes manifests repo
 
@@ -52,6 +56,8 @@ spec:
           value: "$(tt.params.docker_context)"
         - name: kaniko_extra_args
           value: "$(tt.params.kaniko_extra_args)"
+        - name: repository_submodules
+          value: "$(tt.params.repository_submodules)"
 
       resources:
         {{- include "pipeline.defaultResources" . | nindent 8 }}

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -231,7 +231,7 @@ buildpacks:
 
         - name: remove-dcproj-files
           workingDir: $(resources.inputs.app.path)
-          image: "docker.io/library/bash:latest"
+          image: "docker.io/library/bash:5.1.8"
           imagePullPolicy: IfNotPresent
           resources: {}
           script: |

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -229,6 +229,17 @@ buildpacks:
             chown -R "$(params.user_id):$(params.group_id)" "$(resources.inputs.app.path)"
             echo "semantic version updated"
 
+        - name: remove-dcproj-files
+          workingDir: $(resources.inputs.app.path)
+          image: "docker.io/library/bash:latest"
+          imagePullPolicy: IfNotPresent
+          resources: {}
+          script: |
+            #!/usr/bin/env bash
+            # clean `.dcproj` related files related to local development docker .NET project
+            cd $(resources.inputs.app.path)
+            find . -name '*.dcproj' -type f -delete
+
         - name: build-static
           image: node:$(params.node_version)
           imagePullPolicy: IfNotPresent


### PR DESCRIPTION
These changes are needed for `ovio` project .NET backend build - https://saritasa.atlassian.net/browse/OVIO-4
Currently it is deployed in `ci-experiments` namespace (with `tekton-apps-experiments` and `tekton-pipelines-experiments` charts)