### PR TITLE
feat: add ingore replicas diff to wordpress components and nodeSelector for runPostInstallMountPvcJob

### DIFF
--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -13,7 +13,7 @@ triggersVersions: "v0.16.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.22
+version: 0.1.23
 
 
 maintainers:
@@ -733,6 +733,10 @@ description: |
                     repository: xxx-wordpress
                     pipeline: wordpress-build-pipeline
                     applicationURL: https://xxx.site.url
+                    argocd:
+                      ignoreDeploymentReplicasDiff: true
+                      source:
+                        targetRevision: 15.0.16
                     wordpress:
                       repository_ssh_url: git@github.com:saritasa-nest/xxx-wordpress.git
                       externalDatabase:

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 0.1.21](https://img.shields.io/badge/Version-0.1.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.2](https://img.shields.io/badge/AppVersion-v0.28.2-informational?style=flat-square)
+![Version: 0.1.23](https://img.shields.io/badge/Version-0.1.23-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.2](https://img.shields.io/badge/AppVersion-v0.28.2-informational?style=flat-square)
 
 ## Maintainers
 
@@ -751,6 +751,10 @@ spec:
                   repository: xxx-wordpress
                   pipeline: wordpress-build-pipeline
                   applicationURL: https://xxx.site.url
+                  argocd:
+                    ignoreDeploymentReplicasDiff: true
+                    source:
+                      targetRevision: 15.0.16
                   wordpress:
                     repository_ssh_url: git@github.com:saritasa-nest/xxx-wordpress.git
                     externalDatabase:
@@ -1013,44 +1017,6 @@ spec:
         - CreateNamespace=true
   ```
 
-## enable extraApps
-
-if you want to install additional packages for the project you can use `extraApps` as shown below:
-
-```
-apps:
-  - project: nmbl
-    enabled: true
-    argocd:
-      labels:
-        created-by: DmitrySemenov
-        ops-main: DmitrySemenov
-        ops-secondary: KseniyaShaydurova
-        pm: VadikKuznetsov
-        tm: AlekseyBashirov
-      namespace: staging
-      syncWave: 200
-    mailList: nmbl@saritasa.com
-    devopsMailList: devops+nmbl@saritasa.com
-    jiraURL: https://saritasa.atlassian.net/browse/NMBLCLD
-    tektonURL: https://tekton.proxylegalstaging.com/#/namespaces/ci/pipelineruns
-    slack: client-nmbl-ci
-    kubernetesRepository:
-      name: nmbl-kubernetes-aws
-      branch: feature/add-staging
-      url: git@github.com:saritasa-nest/nmbl-kubernetes-aws.git
-
-    extraApps:
-      - name: nmbl-extra-apps
-        path: dev/argocd/apps
-        repoUrl: git@github.com:saritasa-nest/nmbl-kubernetes-aws.git
-        targetRevision: feature/sync-boilerplate
-
-    components:
-      - name: backend
-        repository: nmbl-backend
-```
-
 ## `chart.valuesTable`
 
 | Key | Type | Default | Description |
@@ -1071,3 +1037,4 @@ apps:
 | slack.prefix | string | `"client"` | channel prefix |
 | slack.suffix | string | `"ci"` | channel suffix |
 | storageClassName | string | `"gp2"` | storage class for PVCs associated with the apps |
+

--- a/charts/tekton-apps/templates/job.yaml
+++ b/charts/tekton-apps/templates/job.yaml
@@ -39,6 +39,8 @@ spec:
           {{- end }}
           {{ end }}
       restartPolicy: Never
+      nodeSelector:
+        {{ toYaml .Values.nodeSelector | nindent 8 }}
       volumes:
       {{- range $project := .Values.apps }}
       {{- range $component := $project.components }}

--- a/charts/tekton-apps/templates/wordpress/argocd_applications.yaml
+++ b/charts/tekton-apps/templates/wordpress/argocd_applications.yaml
@@ -29,6 +29,12 @@ spec:
     jsonPointers:
     - /metadata/labels
     kind: secret
+  {{ if (ternary $argocd.ignoreDeploymentReplicasDiff false (hasKey $argocd "ignoreDeploymentReplicasDiff")) }}
+  - group: apps
+    kind: Deployment
+    jsonPointers:
+    - /spec/replicas
+  {{- end }}
   project: {{ $project.project }}
   source:
     chart: wordpress


### PR DESCRIPTION
- add ability to ignore replicas for wordpress components so we can downscale/freeze namespaces to free resouces
- add ability to run postinstall tekton apps job to mount pvc (to make argo app not progressing) on a specific node selector.