### PR TITLE
feat: add `github-inactivity` helm chart

### DIFF
--- a/charts/github-inactivity/.helmignore
+++ b/charts/github-inactivity/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/github-inactivity/Chart.yaml
+++ b/charts/github-inactivity/Chart.yaml
@@ -1,0 +1,77 @@
+apiVersion: v2
+name: github-inactivity
+
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+maintainers:
+  - url: https://www.saritasa.com/
+    name: Saritasa
+    email: nospam@saritasa.com
+
+description: |
+  A Helm chart for Kubernetes to perform check for github inactive repos. It
+  creates CronJob, which scans github organization repos, checks whether they
+  were inactive for some period and send github notifications to corresponding
+  slack channels and emails about found inactive repos.
+
+  Algorithm:
+
+    1. Search in <github-org> using <github-token> for github teams, which
+    have only not archived repos inactive for <inactive-days-count> of days
+    (repos which had no pushes during this period).
+
+    2. Connect to K8S cluster with <kubeconfig-path> and search for
+    namespaces, which <k8s-ns-github-team-label-name> label value corresponds
+    to github teams with inactive repos.
+
+    3. Extract notifications info from found on the previous step namespaces.
+    This info is located in namespace annotations: slack channels ->
+    <k8s-ns-slack-channels-notify-annotation-name>, emails ->
+    <k8s-ns-emails-notify-annotation-name>.
+
+    4. For each github team, which has corresponding info in namespace in
+    K8S cluster, send `github-inactivity` message to slack channels and
+    emails defined in namespace annotations + send slack message to
+    <default-inactivity-slack-channels> + send email to
+    <default-inactivity-emails>.
+
+    5. There could be left some repos, which have no resources in K8S cluster,
+    but have mot archived inactive repos. Send info about these repos also
+    to <default-inactivity-slack-channels> and <default-inactivity-emails>.
+
+  You can adjust script configuration with below params:
+
+
+  ```yaml
+
+  githubOrg: "saritasa-nest" # required
+  fromEmail: "no-reply@saritasa.com" # required
+
+  # secret, which should contain `GITHUB_TOKEN`, `SLACK_BOT_TOKEN`,
+  # `SENDGRID_API_KEY`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` data
+  githubInactivitySecret: "<your-github-inactivity-secret-name>"
+
+  # config map which should contain kubeconfig to connect to correct EKS
+  kubeconfigConfigMap: "<your-kubeconfig-config-map-name>"
+
+  # extra ENV vars needed for required script execution
+  githubInactivityExtraEnvVars:
+    INACTIVE_DAYS_COUNT: 190
+    DEFAULT_INACTIVITY_EMAILS: "devops@saritasa.com"
+    DEFAULT_INACTIVITY_SLACK_CHANNELS: "client-inactive-projects"
+    ERRORS_EMAILS: "devops@saritasa.com"
+    K8S_NS_GITHUB_TEAM_LABEL_NAME: "github.com/saritasa-nest.team"
+    K8S_NS_SLACK_CHANNELS_NOTIFY_ANNOTATION_NAME: "saritasa.com/slack.channels.notify"
+    K8S_NS_EMAILS_NOTIFY_ANNOTATION_NAME: "saritasa.com/emails.notify"
+
+  githubOrg: "saritasa-nest"
+  fromEmail: "no-reply@saritasa.com"
+  kubeconfigMountPath: "<your-kubeconfig-mount-path>"
+  kubeconfigSubPath: "<your-kubeconfig-sub-path>"
+
+  ```

--- a/charts/github-inactivity/README.md
+++ b/charts/github-inactivity/README.md
@@ -1,0 +1,136 @@
+
+# github-inactivity
+
+## `license`
+```
+          ,-.
+ ,     ,-.   ,-.
+/ \   (   )-(   )
+\ |  ,.>-(   )-<
+ \|,' (   )-(   )
+  Y ___`-'   `-'
+  |/__/   `-'
+  |
+  |
+  |    -hi-
+__|_____________
+
+/* Copyright (C) Saritasa,LLC - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Written by Saritasa Devops Team, April 2022
+ */
+
+```
+
+## `chart.deprecationWarning`
+
+## `chart.name`
+
+github-inactivity
+
+## `chart.version`
+
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Saritasa | <nospam@saritasa.com> | <https://www.saritasa.com/> |
+
+## `chart.description`
+
+A Helm chart for Kubernetes to perform check for github inactive repos. It
+creates CronJob, which scans github organization repos, checks whether they
+were inactive for some period and send github notifications to corresponding
+slack channels and emails about found inactive repos.
+
+Algorithm:
+
+  1. Search in <github-org> using <github-token> for github teams, which
+  have only not archived repos inactive for <inactive-days-count> of days
+  (repos which had no pushes during this period).
+
+  2. Connect to K8S cluster with <kubeconfig-path> and search for
+  namespaces, which <k8s-ns-github-team-label-name> label value corresponds
+  to github teams with inactive repos.
+
+  3. Extract notifications info from found on the previous step namespaces.
+  This info is located in namespace annotations: slack channels ->
+  <k8s-ns-slack-channels-notify-annotation-name>, emails ->
+  <k8s-ns-emails-notify-annotation-name>.
+
+  4. For each github team, which has corresponding info in namespace in
+  K8S cluster, send `github-inactivity` message to slack channels and
+  emails defined in namespace annotations + send slack message to
+  <default-inactivity-slack-channels> + send email to
+  <default-inactivity-emails>.
+
+  5. There could be left some repos, which have no resources in K8S cluster,
+  but have mot archived inactive repos. Send info about these repos also
+  to <default-inactivity-slack-channels> and <default-inactivity-emails>.
+
+You can adjust script configuration with below params:
+
+```yaml
+
+githubOrg: "saritasa-nest" # required
+fromEmail: "no-reply@saritasa.com" # required
+
+# secret, which should contain `GITHUB_TOKEN`, `SLACK_BOT_TOKEN`,
+# `SENDGRID_API_KEY`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` data
+githubInactivitySecret: "<your-github-inactivity-secret-name>"
+
+# config map which should contain kubeconfig to connect to correct EKS
+kubeconfigConfigMap: "<your-kubeconfig-config-map-name>"
+
+# extra ENV vars needed for required script execution
+githubInactivityExtraEnvVars:
+  INACTIVE_DAYS_COUNT: 190
+  DEFAULT_INACTIVITY_EMAILS: "devops@saritasa.com"
+  DEFAULT_INACTIVITY_SLACK_CHANNELS: "client-inactive-projects"
+  ERRORS_EMAILS: "devops@saritasa.com"
+  K8S_NS_GITHUB_TEAM_LABEL_NAME: "github.com/saritasa-nest.team"
+  K8S_NS_SLACK_CHANNELS_NOTIFY_ANNOTATION_NAME: "saritasa.com/slack.channels.notify"
+  K8S_NS_EMAILS_NOTIFY_ANNOTATION_NAME: "saritasa.com/emails.notify"
+
+githubOrg: "saritasa-nest"
+fromEmail: "no-reply@saritasa.com"
+kubeconfigMountPath: "<your-kubeconfig-mount-path>"
+kubeconfigSubPath: "<your-kubeconfig-sub-path>"
+
+```
+
+## `chart.valuesTable`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| concurrencyPolicy | string | `"Forbid"` | not allow concurrent job builds |
+| cronJobSecurityContext | object | `{}` |  |
+| environment | string | `""` | name of the environment you're placing the github-inactivity for like dev, prod, staging |
+| failedJobsHistoryLimit | int | `5` |  |
+| fromEmail | string | `""` | sender email for inactive repos notifications |
+| fullnameOverride | string | `""` |  |
+| githubInactivityExtraEnvs | object | `{}` | extra ENV vars needed for required script execution (default values are show below, you can change them if it is needed)  INACTIVE_DAYS_COUNT: 190 DEFAULT_INACTIVITY_EMAILS: "" DEFAULT_INACTIVITY_SLACK_CHANNELS: "" ERRORS_EMAILS: "" K8S_NS_GITHUB_TEAM_LABEL_NAME: "github.com/saritasa-nest.team" K8S_NS_SLACK_CHANNELS_NOTIFY_ANNOTATION_NAME: "saritasa.com/slack.channels.notify" K8S_NS_EMAILS_NOTIFY_ANNOTATION_NAME: "saritasa.com/emails.notify" |
+| githubInactivitySecret | string | `"github-inactivity-secret"` |  |
+| githubOrg | string | `""` | name of github-organization in which inactive repos should be found |
+| image.pullPolicy | string | `"IfNotPresent"` | pull policy |
+| image.repository | string | `"public.ecr.aws/saritasa/github-inactivity"` | container repository, adjust in https://github.com/saritasa-nest/saritasa-devops-docker-images/pull/29 |
+| image.tag | string | `"0.1"` | Overrides the image tag whose default is the chart appVersion. |
+| imagePullSecrets | list | `[]` | credentials for docker login |
+| kubeconfigConfigMap | string | `"github-inactivity-kubeconfig-cm"` |  |
+| kubeconfigMountPath | string | `"/workspace/kubeconfig/eks-config"` |  |
+| kubeconfigSubPath | string | `"eks-config"` |  |
+| nameOverride | string | `""` |  |
+| nodeSelector | object | `{}` |  |
+| restartPolicy | string | `"Never"` |  |
+| schedule | string | `"0 0 1 * *"` | run job in the 1st day of the month |
+| securityContext | object | `{}` |  |
+| serviceAccount.annotations | object | `{}` | Annotations to add to the service account |
+| serviceAccount.create | bool | `true` | Specifies whether a service account should be created |
+| serviceAccount.name | string | `""` | The name of the service account to use. If not set and create is true, a name is generated using the fullname template |
+| successfulJobsHistoryLimit | int | `5` |  |
+
+----------------------------------------------
+Autogenerated from chart metadata using [helm-docs v1.11.0](https://github.com/norwoodj/helm-docs/releases/v1.11.0)

--- a/charts/github-inactivity/README.md.gotmpl
+++ b/charts/github-inactivity/README.md.gotmpl
@@ -1,0 +1,27 @@
+{{ template "chart.header" . }}
+
+## `license`
+{{ template "license" . }}
+
+## `chart.deprecationWarning`
+{{ template "chart.deprecationWarning" . }}
+
+## `chart.name`
+
+{{ template "chart.name" . }}
+
+## `chart.version`
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+## `chart.description`
+
+{{ template "chart.description" . }}
+
+## `chart.valuesTable`
+
+{{ template "chart.valuesTable" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/github-inactivity/templates/_helpers.tpl
+++ b/charts/github-inactivity/templates/_helpers.tpl
@@ -1,0 +1,74 @@
+{{/*
+Expand the name of the chart.
+*/}}
+{{- define "github-inactivity.name" -}}
+{{- default .Chart.Name .Values.nameOverride | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Create a default fully qualified app name.
+We truncate at 63 chars because some Kubernetes name fields are limited to this (by the DNS naming spec).
+If release name contains chart name it will be used as a full name.
+*/}}
+{{- define "github-inactivity.fullname" -}}
+{{- if .Values.fullnameOverride  }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- else if .Values.environment }}
+{{- .Values.fullnameOverride | trunc 63 | trimSuffix "-" }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- printf "%s-%s" .Values.environment $name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- $name := default .Chart.Name .Values.nameOverride }}
+{{- if contains $name .Release.Name }}
+{{- .Release.Name | trunc 63 | trimSuffix "-" }}
+{{- else }}
+{{- printf "%s-%s" .Release.Name $name | trunc 63 | trimSuffix "-" }}
+{{- end }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "github-inactivity.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "github-inactivity.labels" -}}
+helm.sh/chart: {{ include "github-inactivity.chart" . }}
+{{ include "github-inactivity.selectorLabels" . }}
+{{- if .Chart.AppVersion }}
+app.kubernetes.io/version: {{ .Chart.AppVersion | quote }}
+{{- end }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+{{- end }}
+
+{{/*
+Selector labels
+*/}}
+{{- define "github-inactivity.selectorLabels" -}}
+app.kubernetes.io/name: {{ include "github-inactivity.name" . }}
+app.kubernetes.io/instance: {{ .Release.Name }}
+maintenance: 'true'
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "github-inactivity.serviceAccountName" -}}
+{{- if .Values.serviceAccount.create }}
+{{- default (include "github-inactivity.fullname" .) .Values.serviceAccount.name }}
+{{- else }}
+{{- default "default" .Values.serviceAccount.name }}
+{{- end }}
+{{- end }}
+
+{{/*
+Create the name of the service account to use
+*/}}
+{{- define "github-inactivity.required" -}}
+{{ required (printf "Field `%s` is required!" .field_name) .field_value }}
+{{- end }}

--- a/charts/github-inactivity/templates/configmap.yaml
+++ b/charts/github-inactivity/templates/configmap.yaml
@@ -1,0 +1,11 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ include "github-inactivity.fullname" . }}
+data:
+  GITHUB_ORG: {{ include ("github-inactivity.required") (dict "field_name" "githubOrg" "field_value" .Values.githubOrg) }}
+  FROM_EMAIL: {{ include ("github-inactivity.required") (dict "field_name" "fromEmail" "field_value" .Values.fromEmail) }}
+  KUBECONFIG_PATH: {{ .Values.kubeconfigMountPath }}
+  {{- range $key, $value := .Values.githubInactivityExtraEnvs }}
+  {{ $key }}: {{ $value | quote }}
+  {{- end }}

--- a/charts/github-inactivity/templates/cronjob.yaml
+++ b/charts/github-inactivity/templates/cronjob.yaml
@@ -1,0 +1,46 @@
+apiVersion: batch/v1
+kind: CronJob
+metadata:
+  name: {{ include "github-inactivity.fullname" . }}
+  labels:
+    {{- include "github-inactivity.labels" . | nindent 4 }}
+spec:
+  concurrencyPolicy: {{ .Values.concurrencyPolicy }}
+  schedule: {{ .Values.schedule }}
+  successfulJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
+  failedJobsHistoryLimit: {{ .Values.successfulJobsHistoryLimit }}
+  jobTemplate:
+    spec:
+      template:
+        spec:
+          {{- with .Values.imagePullSecrets }}
+          imagePullSecrets:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          serviceAccountName: {{ include "github-inactivity.serviceAccountName" . }}
+          securityContext:
+            {{- toYaml .Values.cronJobSecurityContext | nindent 12 }}
+          restartPolicy: {{ .Values.restartPolicy }}
+          {{- with .Values.nodeSelector }}
+          nodeSelector:
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
+          containers:
+            - name: {{ .Chart.Name }}
+              securityContext:
+                {{- toYaml .Values.securityContext | nindent 16 }}
+              image: "{{ .Values.image.repository }}:{{ .Values.image.tag | default .Chart.AppVersion }}"
+              imagePullPolicy: {{ .Values.image.pullPolicy }}
+              envFrom:
+                - configMapRef:
+                    name: {{ include "github-inactivity.fullname" . }}
+                - secretRef:
+                    name: {{ .Values.githubInactivitySecret }}
+              volumeMounts:
+                - name: kubeconfig
+                  mountPath: {{ .Values.kubeconfigMountPath }}
+                  subPath: {{ .Values.kubeconfigSubPath }}
+          volumes:
+            - name: kubeconfig
+              configMap:
+                name: {{ .Values.kubeconfigConfigMap }}

--- a/charts/github-inactivity/templates/serviceaccount.yaml
+++ b/charts/github-inactivity/templates/serviceaccount.yaml
@@ -1,0 +1,12 @@
+{{- if .Values.serviceAccount.create -}}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ include "github-inactivity.serviceAccountName" . }}
+  labels:
+    {{- include "github-inactivity.labels" . | nindent 4 }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/github-inactivity/values.yaml
+++ b/charts/github-inactivity/values.yaml
@@ -1,0 +1,74 @@
+# Default values for github-inactivity.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+image:
+  # -- container repository, adjust in https://github.com/saritasa-nest/saritasa-devops-docker-images/pull/29
+  repository: public.ecr.aws/saritasa/github-inactivity
+  # -- pull policy
+  pullPolicy: IfNotPresent
+  # -- Overrides the image tag whose default is the chart appVersion.
+  tag: "0.1"
+
+# -- name of the environment you're placing the github-inactivity for like dev, prod, staging
+environment: ""
+
+# -- not allow concurrent job builds
+concurrencyPolicy: "Forbid"
+
+# -- run job in the 1st day of the month
+schedule: "0 0 1 * *"
+
+successfulJobsHistoryLimit: 5
+failedJobsHistoryLimit: 5
+
+# -- credentials for docker login
+imagePullSecrets: []
+nameOverride: ""
+fullnameOverride: ""
+
+serviceAccount:
+  # -- Specifies whether a service account should be created
+  create: true
+  # -- Annotations to add to the service account
+  annotations: {}
+  # -- The name of the service account to use. If not set and create is true, a name is generated using the fullname template
+  name: ""
+
+cronJobSecurityContext: {}
+
+securityContext: {}
+
+nodeSelector: {}
+
+restartPolicy: "Never"
+
+# -- name of github-organization in which inactive repos should be found
+githubOrg: ""
+
+# -- sender email for inactive repos notifications
+fromEmail: ""
+
+# -- extra ENV vars needed for required script execution (default values are show below, you can change them if it is needed)
+#
+# INACTIVE_DAYS_COUNT: 190
+# DEFAULT_INACTIVITY_EMAILS: ""
+# DEFAULT_INACTIVITY_SLACK_CHANNELS: ""
+# ERRORS_EMAILS: ""
+# K8S_NS_GITHUB_TEAM_LABEL_NAME: "github.com/saritasa-nest.team"
+# K8S_NS_SLACK_CHANNELS_NOTIFY_ANNOTATION_NAME: "saritasa.com/slack.channels.notify"
+# K8S_NS_EMAILS_NOTIFY_ANNOTATION_NAME: "saritasa.com/emails.notify"
+githubInactivityExtraEnvs: {}
+
+# secret, which should contain `GITHUB_TOKEN`, `SLACK_BOT_TOKEN`,
+# `SENDGRID_API_KEY`, `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` data
+githubInactivitySecret: "github-inactivity-secret"
+
+# config map which should contain kubeconfig to connect to correct EKS
+kubeconfigConfigMap: "github-inactivity-kubeconfig-cm"
+
+# mount path where kubeconfig file should be stored
+kubeconfigMountPath: "/workspace/kubeconfig/eks-config"
+
+# sub path where kubeconfig file should be stored
+kubeconfigSubPath: "eks-config"


### PR DESCRIPTION
Add new `github-inactivity` helm chart: https://saritasa.atlassian.net/browse/SD-448 (search inactive repos in organization github and notify required people in slack and email)

Implemented this app on `cloud` EKS, added deployment with helm chart for simplicity: https://deploy.saritasa.cloud/applications/github-inactivity?view=tree&resource=

Other related PRs:
- https://github.com/saritasa-nest/saritasa-devops-github-activity/pull/2
- https://github.com/saritasa-nest/saritasa-terraform-modules/pull/46
- https://github.com/saritasa-nest/saritasa-cloud-kubernetes-aws/pull/26