### PR TITLE
[tekton-pipelines] - new 'kubeval' step

### DIFF
--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.32-dev.1
+version: 0.1.32-dev.2
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.32-dev
+version: 0.1.32-dev.1
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.33-dev
+version: 0.1.32-dev
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.32-dev.4
+version: 0.1.32
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.31
+version: 0.1.33-dev
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.32-dev.2
+version: 0.1.32-dev.3
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.32-dev.3
+version: 0.1.32-dev.4
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 0.1.32-dev](https://img.shields.io/badge/Version-0.1.32--dev-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.32](https://img.shields.io/badge/Version-0.1.32-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 
@@ -189,7 +189,7 @@ to specific project trigger-binding:
 | images.kustomize | string | `"k8s.gcr.io/kustomize/kustomize:v4.5.4"` | kustomize cli |
 | images.python | string | `"saritasallc/python3:0.4"` | python image |
 | images.slack | string | `"cloudposse/slack-notifier:0.4.0"` | slack notifier |
-| images.yamlfix | string | `"public.ecr.aws/saritasa/yamlfix:1.1.0"` | yamlfix image - format yaml files |
+| images.yamlfix | string | `"public.ecr.aws/saritasa/yamlfix:latest"` | yamlfix image - format yaml files |
 | kaniko.enabled | bool | `false` | should we enable the kaniko pipeline |
 | podTemplate | object | see values.yaml | default configuration to be added into each pod created by tekton engine we want to plave them in a specific node with added tolerations/taints. |
 | podTemplate.nodeSelector | object | `{"ci":"true"}` | node selector for pods spawned by tekton |

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 0.1.33-dev](https://img.shields.io/badge/Version-0.1.33--dev-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.32-dev](https://img.shields.io/badge/Version-0.1.32--dev-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 
@@ -185,10 +185,11 @@ to specific project trigger-binding:
 | images.git | string | `"alpine/git:v2.32.0"` | git image |
 | images.kaniko | string | `"gcr.io/kaniko-project/executor@sha256:b44b0744b450e731b5a5213058792cd8d3a6a14c119cf6b1f143704f22a7c650"` | kaniko image used to build containers containing docker files - v1.8.1, uploaded April 5 2022 |
 | images.kubectl | string | `"bitnami/kubectl:1.22.10"` | kubectl cli |
+| images.kubeval | string | `"public.ecr.aws/saritasa/kubeval:0.16.1"` | kubeval image - validate Kubernetes manifests |
 | images.kustomize | string | `"k8s.gcr.io/kustomize/kustomize:v4.5.4"` | kustomize cli |
 | images.python | string | `"saritasallc/python3:0.4"` | python image |
 | images.slack | string | `"cloudposse/slack-notifier:0.4.0"` | slack notifier |
-| images.yamlfix | string | `"public.ecr.aws/saritasa/yamlfix:1.8.0"` | yamlfix image - format yaml files |
+| images.yamlfix | string | `"public.ecr.aws/saritasa/yamlfix:1.1.0"` | yamlfix image - format yaml files |
 | kaniko.enabled | bool | `false` | should we enable the kaniko pipeline |
 | podTemplate | object | see values.yaml | default configuration to be added into each pod created by tekton engine we want to plave them in a specific node with added tolerations/taints. |
 | podTemplate.nodeSelector | object | `{"ci":"true"}` | node selector for pods spawned by tekton |

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 0.1.31](https://img.shields.io/badge/Version-0.1.31-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.33-dev](https://img.shields.io/badge/Version-0.1.33--dev-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/templates/common/tasks/kustomize.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/kustomize.yaml
@@ -67,7 +67,15 @@ spec:
           CONFIG=$(realpath .yamlfix.toml)
         fi
 
-        find apps -iname "*.yaml" -exec yamlfix --config-file=$CONFIG {} \;
+        find $(params.kustomize_overlay_path) -iname "*.yaml" -exec yamlfix --config-file=$CONFIG {} \;
+
+    - name: kubeval
+      image: {{ .Values.images.kubeval | default "public.ecr.aws/saritasa/kubeval:latest"}}
+      imagePullPolicy: {{ .Values.imagePullPolicy }}
+      workingDir: $(resources.inputs.kubernetes-repo.path)
+      script: |
+        KUBEVAL_SCHEMA_LOCATION=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master
+        kustomize build $(params.kustomize_overlay_path) | kubeval -f -
 
     - name: git-push
       image: {{ .Values.images.git | default "alpine/git:latest" }}

--- a/charts/tekton-pipelines/templates/common/tasks/kustomize.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/kustomize.yaml
@@ -74,7 +74,7 @@ spec:
       imagePullPolicy: {{ .Values.imagePullPolicy }}
       workingDir: $(resources.inputs.kubernetes-repo.path)
       script: |
-        KUBEVAL_SCHEMA_LOCATION=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master
+        export KUBEVAL_SCHEMA_LOCATION=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master
         kustomize build $(params.kustomize_overlay_path) | kubeval -f -
 
     - name: git-push

--- a/charts/tekton-pipelines/templates/common/tasks/kustomize.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/kustomize.yaml
@@ -74,8 +74,15 @@ spec:
       imagePullPolicy: {{ .Values.imagePullPolicy }}
       workingDir: $(resources.inputs.kubernetes-repo.path)
       script: |
+        APISERVER=https://kubernetes.default.svc
+        SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
+        TOKEN=$(cat ${SERVICEACCOUNT}/token)
+        CACERT=${SERVICEACCOUNT}/ca.crt
+        KUBERNETES_INFO=$(curl --cacert ${CACERT} --header "Authorization: Bearer ${TOKEN}" -X GET ${APISERVER}/version)
+        KUBERNETES_VERSION=$(echo $KUBERNETES_INFO | jq -r ".gitVersion" | grep -oE '\d\d?\.\d\d?\.\d\d?')
+
         export KUBEVAL_SCHEMA_LOCATION=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master
-        kustomize build $(params.kustomize_overlay_path) | kubeval --ignore-missing-schemas --kubernetes-version=1.24.0 -f -
+        kustomize build $(params.kustomize_overlay_path) | kubeval --ignore-missing-schemas --kubernetes-version=$KUBERNETES_VERSION -f -
 
     - name: git-push
       image: {{ .Values.images.git | default "alpine/git:latest" }}

--- a/charts/tekton-pipelines/templates/common/tasks/kustomize.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/kustomize.yaml
@@ -75,7 +75,7 @@ spec:
       workingDir: $(resources.inputs.kubernetes-repo.path)
       script: |
         export KUBEVAL_SCHEMA_LOCATION=https://raw.githubusercontent.com/yannh/kubernetes-json-schema/master
-        kustomize build $(params.kustomize_overlay_path) | kubeval -f -
+        kustomize build $(params.kustomize_overlay_path) | kubeval --ignore-missing-schemas --kubernetes-version=1.24.0 -f -
 
     - name: git-push
       image: {{ .Values.images.git | default "alpine/git:latest" }}

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -24,7 +24,7 @@ images:
   # -- python image
   python:    saritasallc/python3:0.4 # https://github.com/saritasa-nest/saritasa-devops-docker-images/tree/main/public/python/python3-alpine-boto
   # -- yamlfix image - format yaml files
-  yamlfix:   public.ecr.aws/saritasa/yamlfix:latest # https://lyz-code.github.io/yamlfix/
+  yamlfix:   public.ecr.aws/saritasa/yamlfix:1.8.1 # https://lyz-code.github.io/yamlfix/
   # -- kubeval image - validate Kubernetes manifests
   kubeval:   public.ecr.aws/saritasa/kubeval:0.16.1 # https://kubeval.instrumenta.dev/
 

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -24,7 +24,8 @@ images:
   # -- python image
   python:    saritasallc/python3:0.4 # https://github.com/saritasa-nest/saritasa-devops-docker-images/tree/main/public/python/python3-alpine-boto
   # -- yamlfix image - format yaml files
-  yamlfix:   public.ecr.aws/saritasa/yamlfix:1.8.0 # https://lyz-code.github.io/yamlfix/
+  yamlfix:   public.ecr.aws/saritasa/yamlfix:1.1.0 # https://lyz-code.github.io/yamlfix/
+  # -- kubeval image - validate Kubernetes manifests
   kubeval:   public.ecr.aws/saritasa/kubeval:0.16.1 # https://kubeval.instrumenta.dev/
 
 

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -24,7 +24,7 @@ images:
   # -- python image
   python:    saritasallc/python3:0.4 # https://github.com/saritasa-nest/saritasa-devops-docker-images/tree/main/public/python/python3-alpine-boto
   # -- yamlfix image - format yaml files
-  yamlfix:   public.ecr.aws/saritasa/yamlfix:1.1.0 # https://lyz-code.github.io/yamlfix/
+  yamlfix:   public.ecr.aws/saritasa/yamlfix:1.1.1 # https://lyz-code.github.io/yamlfix/
   # -- kubeval image - validate Kubernetes manifests
   kubeval:   public.ecr.aws/saritasa/kubeval:0.16.1 # https://kubeval.instrumenta.dev/
 

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -24,7 +24,7 @@ images:
   # -- python image
   python:    saritasallc/python3:0.4 # https://github.com/saritasa-nest/saritasa-devops-docker-images/tree/main/public/python/python3-alpine-boto
   # -- yamlfix image - format yaml files
-  yamlfix:   public.ecr.aws/saritasa/yamlfix:1.1.1 # https://lyz-code.github.io/yamlfix/
+  yamlfix:   public.ecr.aws/saritasa/yamlfix:latest # https://lyz-code.github.io/yamlfix/
   # -- kubeval image - validate Kubernetes manifests
   kubeval:   public.ecr.aws/saritasa/kubeval:0.16.1 # https://kubeval.instrumenta.dev/
 

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -25,6 +25,7 @@ images:
   python:    saritasallc/python3:0.4 # https://github.com/saritasa-nest/saritasa-devops-docker-images/tree/main/public/python/python3-alpine-boto
   # -- yamlfix image - format yaml files
   yamlfix:   public.ecr.aws/saritasa/yamlfix:1.8.0 # https://lyz-code.github.io/yamlfix/
+  kubeval:   public.ecr.aws/saritasa/kubeval:0.16.1 # https://kubeval.instrumenta.dev/
 
 
 # ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐


### PR DESCRIPTION
To mitigate problem, when `yamlfix` breaks deployment:
1. Use https://kubeval.instrumenta.dev/ which validates Kubernetes resources agaist JSON Schema for all Kubernetes resources (repository https://github.com/yannh/kubernetes-json-schema content is automatically generated from Kubernetes source code)
2. Apply Yamlfix only to overlay (`apps/{app}/manifests/{env}`), affected by `kustomize`, not whole `apps` folder (ex. we won't break production by commit to `develop` branch). Also, commit to frontend will not break backend and vice versa.