### PR TITLE
[tekton-pipelines] - deprecate k8s.gcr.io repo

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 #
 # For details see https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-features/customizing-your-repository/about-code-owners
 
-*  @dmitry-mightydevops @DanilaKazakevich @kseniyashaydurova @MikhailKorol-saritasa @owlfog @populov @roman-mightydevops @SergeyDeminSaritasa @udaltsovra
+*  @dmitry-mightydevops @DanilaKazakevich @kseniyashaydurova @MikhailKorol-saritasa @owlfog @populov @roman-mightydevops @SergeyDeminSaritasa @udaltsovra @luciano-buono

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.33
+version: 0.1.34-dev.1
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 0.1.33](https://img.shields.io/badge/Version-0.1.33-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.34-dev.1](https://img.shields.io/badge/Version-0.1.34--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 
@@ -186,7 +186,7 @@ to specific project trigger-binding:
 | images.kaniko | string | `"gcr.io/kaniko-project/executor@sha256:b44b0744b450e731b5a5213058792cd8d3a6a14c119cf6b1f143704f22a7c650"` | kaniko image used to build containers containing docker files - v1.8.1, uploaded April 5 2022 |
 | images.kubectl | string | `"bitnami/kubectl:1.22.10"` | kubectl cli |
 | images.kubeval | string | `"public.ecr.aws/saritasa/kubeval:0.16.1"` | kubeval image - validate Kubernetes manifests |
-| images.kustomize | string | `"k8s.gcr.io/kustomize/kustomize:v4.5.4"` | kustomize cli |
+| images.kustomize | string | `"registry.k8s.io/kustomize/kustomize:v5.0.0"` | kustomize cli |
 | images.python | string | `"saritasallc/python3:0.4"` | python image |
 | images.slack | string | `"cloudposse/slack-notifier:0.4.0"` | slack notifier |
 | images.yamlfix | string | `"public.ecr.aws/saritasa/yamlfix:1.8.1"` | yamlfix image - format yaml files |

--- a/charts/tekton-pipelines/templates/common/tasks/kustomize.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/kustomize.yaml
@@ -47,7 +47,7 @@ spec:
         git config user.name "tekton-kustomize"
 
     - name: update-image
-      image: {{ .Values.images.kustomize | default "k8s.gcr.io/kustomize/kustomize:latest"}}
+      image: {{ .Values.images.kustomize | default "registry.k8s.io/kustomize/kustomize:v5.0.0"}}
       imagePullPolicy: {{ .Values.imagePullPolicy }}
       workingDir: $(resources.inputs.kubernetes-repo.path)
       script: |

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -16,7 +16,7 @@ images:
   # -- git image
   git: alpine/git:v2.32.0
   # -- kustomize cli
-  kustomize: k8s.gcr.io/kustomize/kustomize:v4.5.4  # https://github.com/kubernetes/k8s.io/blob/main/k8s.gcr.io/images/k8s-staging-kustomize/images.yaml
+  kustomize: registry.k8s.io/kustomize/kustomize:v5.0.0  # https://kubectl.docs.kubernetes.io/installation/kustomize/docker/
   # -- kubectl cli
   kubectl: bitnami/kubectl:1.22.10
   # -- slack notifier


### PR DESCRIPTION
# Summary

deprecate `k8s.gcr.io` which was used by our tekton kustomize task
https://kubernetes.io/blog/2023/02/06/k8s-gcr-io-freeze-announcement/

```
➜ k ice image -A G k8s.gcr.io                                   
ci                               ats-dart-backend-dev-kaniko-build-pipeline-run-cm5j8-kust-tvslh  step-update-image                      IfNotPresent  k8s.gcr.io/kustomize/kustomize                                                  v4.5.4
ci                               ats-dart-backend-dev-kaniko-build-pipeline-run-vzpw2-kust-sdgcm  step-update-image                      IfNotPresent  k8s.gcr.io/kustomize/kustomize                                                  v4.5.4
ci                               ats-dart-frontend-sales-dev-build-pipeline-run-z6mc9-kust-gwzlw  step-update-image                      IfNotPresent  k8s.gcr.io/kustomize/kustomize                                                  v4.5.4
ci                               colfa-backend-dev-build-pipeline-run-26hxf-kustomize-7zvh-jgcns  step-update-image                      IfNotPresent  k8s.gcr.io/kustomize/kustomize                                                  v4.5.4

```