### PR TITLE
fix: secret provisioning for wp

### DIFF
--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: "v0.28.2"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.8-dev.0
+version: 0.2.8
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: "v0.28.2"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.7
+version: 0.2.8-dev.0
 
 maintainers:
   - url: https://www.saritasa.com/
@@ -287,8 +287,7 @@ description: |
     - apps[PROJECT].components[NAME].wordpress.wordpressTablePrefix - wordpress DB tables prefix (default: wp_)
     - apps[PROJECT].components[NAME].wordpress.wordpressScheme - wordpress access scheme (default: "https")
     - apps[PROJECT].components[NAME].wordpress.wordpressEmail - target for sending emails (default: devops+<client-name>@saritasa.com)
-    - apps[PROJECT].components[NAME].wordpress.existingSecret - name of existing in kubernetes secret with wp admin auth info (default: "<project_name>-<component_name>-<env>",
-      i.e. "taco-wordpress-dev")
+    - apps[PROJECT].components[NAME].wordpress.existingSecret - name of existing in kubernetes secret with wp admin and smtp auth info, should contain sections: 'wordpress-password', 'smtp-password'.
     - apps[PROJECT].components[NAME].wordpress.smtpHost - SMTP host for sending emails (default: mailhog.mailhog.svc.cluster.local)
     - apps[PROJECT].components[NAME].wordpress.smtpPort - SMTP port for sending emails (default: 1025)
     - apps[PROJECT].components[NAME].wordpress.smtpUser - SMTP user for sending emails (default: <project_name>, i.e. taco)

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 0.2.7](https://img.shields.io/badge/Version-0.2.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.2](https://img.shields.io/badge/AppVersion-v0.28.2-informational?style=flat-square)
+![Version: 0.2.8-dev.0](https://img.shields.io/badge/Version-0.2.8--dev.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.2](https://img.shields.io/badge/AppVersion-v0.28.2-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 0.2.8-dev.0](https://img.shields.io/badge/Version-0.2.8--dev.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.2](https://img.shields.io/badge/AppVersion-v0.28.2-informational?style=flat-square)
+![Version: 0.2.8](https://img.shields.io/badge/Version-0.2.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.28.2](https://img.shields.io/badge/AppVersion-v0.28.2-informational?style=flat-square)
 
 ## Maintainers
 
@@ -308,8 +308,7 @@ spec:
   - apps[PROJECT].components[NAME].wordpress.wordpressTablePrefix - wordpress DB tables prefix (default: wp_)
   - apps[PROJECT].components[NAME].wordpress.wordpressScheme - wordpress access scheme (default: "https")
   - apps[PROJECT].components[NAME].wordpress.wordpressEmail - target for sending emails (default: devops+<client-name>@saritasa.com)
-  - apps[PROJECT].components[NAME].wordpress.existingSecret - name of existing in kubernetes secret with wp admin auth info (default: "<project_name>-<component_name>-<env>",
-    i.e. "taco-wordpress-dev")
+  - apps[PROJECT].components[NAME].wordpress.existingSecret - name of existing in kubernetes secret with wp admin and smtp auth info, should contain sections: 'wordpress-password', 'smtp-password'.
   - apps[PROJECT].components[NAME].wordpress.smtpHost - SMTP host for sending emails (default: mailhog.mailhog.svc.cluster.local)
   - apps[PROJECT].components[NAME].wordpress.smtpPort - SMTP port for sending emails (default: 1025)
   - apps[PROJECT].components[NAME].wordpress.smtpUser - SMTP user for sending emails (default: <project_name>, i.e. taco)

--- a/charts/tekton-apps/templates/wordpress/argocd_applications.yaml
+++ b/charts/tekton-apps/templates/wordpress/argocd_applications.yaml
@@ -248,8 +248,10 @@ spec:
         wordpressScheme: {{ .wordpressScheme | default "https" }}
         wordpressTablePrefix: {{ .wordpressTablePrefix | default "wp_" }}
         allowEmptyPassword: false
-        existingSecret: {{ .existingSecret | default (printf "%s-%s-%s" $project.project $component.name $projectEnvironment) }}
-
+        {{ if .existingSecret }}
+        existingSecret: {{ .existingSecret }}
+        smtpExistingSecret: {{ .existingSecret }}
+        {{- end }}
         smtpHost: {{ .smtpHost | default "mailhog.mailhog.svc.cluster.local" }}
         smtpPort: {{ .smtpHort | default 1025 }}
         smtpUser: {{ .smtpUser | default $project.project }}


### PR DESCRIPTION
Resolve secret provision for wp via tekton-apps.

If we provide `.existingSecret` with `.smtpPassword` helm creates secret without `wordpress-password` and reverts manual update for it. See logic here: https://github.com/bitnami/charts/blob/main/bitnami/wordpress/templates/secrets.yaml


Helm uses same logic for naming so that changes won't break already existed deployments. 

Example of failure: https://deploy.saritasa.rocks/applications/premierfoodsafety-wordpress-dev