### PR TITLE
feat: less frequent healthchecks for WordPress

### DIFF
--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: "v0.29.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.11
+version: 0.2.12-dev
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: "v0.29.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.12-dev
+version: 0.2.12
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 0.2.11](https://img.shields.io/badge/Version-0.2.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
+![Version: 0.2.12-dev](https://img.shields.io/badge/Version-0.2.12--dev-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 0.2.12-dev](https://img.shields.io/badge/Version-0.2.12--dev-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
+![Version: 0.2.12](https://img.shields.io/badge/Version-0.2.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-apps/templates/wordpress/argocd_applications.yaml
+++ b/charts/tekton-apps/templates/wordpress/argocd_applications.yaml
@@ -185,6 +185,7 @@ spec:
             path: /wp-admin/install.php
             port: 8080
             scheme: HTTP
+          periodSeconds: 120
 
         readinessProbe:
           enabled: true
@@ -192,6 +193,7 @@ spec:
             path: /wp-admin/install.php
             port: 8080
             scheme: HTTP
+          periodSeconds: 120
 
         service:
           type: ClusterIP


### PR DESCRIPTION
PHP node is overloaded. By defautl bitnami helmchart performs liveness/readness healthchecks every 10 seconds (ping to `GET /wp-admin/install.php` which is non-trivial check). 
So by default each WP project consumes arount 5% CPU (~50m) only for healthcecks.

With mutiple WP projects running less frequenet liveness/readness probes execution allows to reduce CPU consumption significantly.

![image](https://github.com/saritasa-nest/saritasa-devops-helm-charts/assets/3766033/c5a74117-4684-47bd-a342-22dafeeb1dd5)
