### PR TITLE
fix: disable hashes for poetry export

### DIFF
--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.38
+version: 0.1.39-dev.1
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.39-dev.1
+version: 0.1.39
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 0.1.38](https://img.shields.io/badge/Version-0.1.38-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.39-dev.1](https://img.shields.io/badge/Version-0.1.39--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 0.1.39-dev.1](https://img.shields.io/badge/Version-0.1.39--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.1.39](https://img.shields.io/badge/Version-0.1.39-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -198,7 +198,7 @@ buildpacks:
                 TARGET="${TARGET},dev"
               fi
               echo "Export '${TARGET}' targets dependencies"
-              poetry export --with ${TARGET} --output requirements.txt
+              poetry export --without-hashes --with ${TARGET} --output requirements.txt
               exit 0
             fi
 


### PR DESCRIPTION
Disable hashes for poetry requirements export

Resolves issue with dependecies in git repos, like this:
```
ERROR: Can't verify hashes for these requirements because we don't have a way to hash version control repositories:
          django-s3direct@ git+https://github.com/Saritasa/django-s3direct.git@6bc6d843b64da8e399b29caed211fccd6e9961a0 from git+https://github.com/Saritasa/django-s3direct.git@6bc6d843b64da8e399b29caed211fccd6e9961a0 (from -r requirements.txt (line 170))
pip install failed:
error: exit status 1
ERROR: failed to build: exit status 1

Step failed
```

Task: https://saritasa.atlassian.net/browse/JC-560