### PR TITLE
feat: add ArgoCD webhook integration

### DIFF
--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: "v0.29.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.12
+version: 0.2.13
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -94,10 +94,13 @@ description: |
                 namespace: prod
                 notifications:
                   annotations:
+                    # In rocks/cloud cluster use slack-token integration:
                     notifications.argoproj.io/subscribe.on-health-degraded.slack: project-vp; project-vp-alarms
                     notifications.argoproj.io/subscribe.on-sync-failed.slack: project-vp-ci; project-vp-alarms
                     notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-vp; project-vp-alarms
                     notifications.argoproj.io/subscribe.on-deployed.slack: project-vp-ci
+                    # In staging/prod client cluster use webhook integration:
+                    notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
               mailList: vp@site.com
               devopsMailList: devops+vp@site.com
               jiraURL: https://site.atlassian.net/browse/vp
@@ -165,7 +168,12 @@ description: |
 
     Above helm chart creates a new ArgoCD project for each project in values, for each component in project's components there is created a separate ArgoCD
     application and required for Tekton ci/cd resources (triggerbindings, roles, configmaps, jobs, serviceaccounts, pvcs and etc).
+
     For each Argocd project, notifications to multiple slack channels with different types of triggers are added. The example above define for each subscription, the slack channels (project-xx, project-xx-ci project-xx-alarms) that should be added by default. This can be modified to add/remove a channel in case of a custom config needed.
+
+    There are two ways of activating notifications, using slack-token integration and using project-webhooks integration.
+    The slack-token allows sending to any slack channel where the app is installed, that's why we should only use it in rocks/cloud cluster and not in clients clusters.
+    The project-webhook integrations can only send to the channel where it's created in Slack app 'client deployments' (https://api.slack.com/apps/A01LM626QTZ/incoming-webhooks?) and it should be used in staging/prod client clusters.
 
     # fill below parameters for each `project` block
 
@@ -340,10 +348,13 @@ description: |
                   namespace: prod
                   notifications:
                     annotations:
+                      # In rocks/cloud cluster use slack-token integration:
                       notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                      # In staging/prod client cluster use webhook integration:
+                      notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
                 mailList: xxx@saritasa.com
                 devopsMailList: devops+xxx@saritasa.com
                 jiraURL: https://saritasa.atlassian.net/browse/xxx
@@ -446,10 +457,13 @@ description: |
                   namespace: xxx
                   notifications:
                     annotations:
+                      # In rocks/cloud cluster use slack-token integration:
                       notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                      # In staging/prod client cluster use webhook integration:
+                      notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
                   sourceRepos:
                     - git@github.com:saritasa-nest/xxx-backend.git
                     - git@github.com:saritasa-nest/xxx-frontend.git
@@ -551,10 +565,13 @@ description: |
                   namespace: xxx-dev
                   notifications:
                     annotations:
+                      # In rocks/cloud cluster use slack-token integration:
                       notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                      # In staging/prod client cluster use webhook integration:
+                      notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
                 mailList: xxx@saritasa.com
                 devopsMailList: devops+xxx@saritasa.com
                 jiraURL: https://saritasa.atlassian.net/browse/xxx
@@ -634,10 +651,13 @@ description: |
                     - argo-cd
                   notifications:
                     annotations:
+                      # In rocks/cloud cluster use slack-token integration:
                       notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                      # In staging/prod client cluster use webhook integration:
+                      notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
                 mailList: xxx@saritasa.com
                 devopsMailList: devops+xxx@saritasa.com
                 jiraURL: https://saritasa.atlassian.net/browse/xxx
@@ -715,10 +735,13 @@ description: |
                     - argo-cd
                   notifications:
                     annotations:
+                      # In rocks/cloud cluster use slack-token integration:
                       notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                      # In staging/prod client cluster use webhook integration:
+                      notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
                 mailList: xxx@saritasa.com
                 devopsMailList: devops+xxx@saritasa.com
                 jiraURL: https://saritasa.atlassian.net/browse/xxx
@@ -796,10 +819,13 @@ description: |
                   namespace: xxx-dev
                   notifications:
                     annotations:
+                      # In rocks/cloud cluster use slack-token integration:
                       notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                      # In staging/prod client cluster use webhook integration:
+                      notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
                 mailList: xxx@saritasa.com
                 devopsMailList: devops+xxx@saritasa.com
                 jiraURL: https://saritasa.atlassian.net/browse/xxx
@@ -877,10 +903,13 @@ description: |
                   namespace: xxx-dev
                   notifications:
                     annotations:
+                      # In rocks/cloud cluster use slack-token integration:
                       notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                      # In staging/prod client cluster use webhook integration:
+                      notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
                 mailList: xxx@saritasa.com
                 devopsMailList: devops+xxx@saritasa.com
                 jiraURL: https://saritasa.atlassian.net/browse/xxx
@@ -959,10 +988,13 @@ description: |
                   namespace: xxx
                   notifications:
                     annotations:
+                      # In rocks/cloud cluster use slack-token integration:
                       notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                      # In staging/prod client cluster use webhook integration:
+                      notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
                   sourceRepos:
                     - https://charts.bitnami.com/bitnami
                 mailList: xxx@saritasa.com
@@ -1039,10 +1071,13 @@ description: |
                   namespace: xxx
                   notifications:
                     annotations:
+                      # In rocks/cloud cluster use slack-token integration:
                       notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                      # In staging/prod client cluster use webhook integration:
+                      notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
                   sourceRepos:
                     - https://charts.bitnami.com/bitnami
                 mailList: xxx@saritasa.com
@@ -1116,10 +1151,13 @@ description: |
                   namespace: xxx
                   notifications:
                     annotations:
+                      # In rocks/cloud cluster use slack-token integration:
                       notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                       notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                      # In staging/prod client cluster use webhook integration:
+                      notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
                   sourceRepos:
                     - https://charts.bitnami.com/bitnami
                     - git@github.com:saritasa-nest/xxx-kubernetes-aws.git

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -115,10 +115,13 @@ spec:
               namespace: prod
               notifications:
                 annotations:
+                  # In rocks/cloud cluster use slack-token integration:
                   notifications.argoproj.io/subscribe.on-health-degraded.slack: project-vp; project-vp-alarms
                   notifications.argoproj.io/subscribe.on-sync-failed.slack: project-vp-ci; project-vp-alarms
                   notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-vp; project-vp-alarms
                   notifications.argoproj.io/subscribe.on-deployed.slack: project-vp-ci
+                  # In staging/prod client cluster use webhook integration:
+                  notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
             mailList: vp@site.com
             devopsMailList: devops+vp@site.com
             jiraURL: https://site.atlassian.net/browse/vp
@@ -186,7 +189,12 @@ spec:
 
   Above helm chart creates a new ArgoCD project for each project in values, for each component in project's components there is created a separate ArgoCD
   application and required for Tekton ci/cd resources (triggerbindings, roles, configmaps, jobs, serviceaccounts, pvcs and etc).
+
   For each Argocd project, notifications to multiple slack channels with different types of triggers are added. The example above define for each subscription, the slack channels (project-xx, project-xx-ci project-xx-alarms) that should be added by default. This can be modified to add/remove a channel in case of a custom config needed.
+
+  There are two ways of activating notifications, using slack-token integration and using project-webhooks integration.
+  The slack-token allows sending to any slack channel where the app is installed, that's why we should only use it in rocks/cloud cluster and not in clients clusters.
+  The project-webhook integrations can only send to the channel where it's created in Slack app 'client deployments' (https://api.slack.com/apps/A01LM626QTZ/incoming-webhooks?) and it should be used in staging/prod client clusters.
 
   # fill below parameters for each `project` block
 
@@ -361,10 +369,13 @@ spec:
                 namespace: prod
                 notifications:
                   annotations:
+                    # In rocks/cloud cluster use slack-token integration:
                     notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                    # In staging/prod client cluster use webhook integration:
+                    notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
               mailList: xxx@saritasa.com
               devopsMailList: devops+xxx@saritasa.com
               jiraURL: https://saritasa.atlassian.net/browse/xxx
@@ -467,10 +478,13 @@ spec:
                 namespace: xxx
                 notifications:
                   annotations:
+                    # In rocks/cloud cluster use slack-token integration:
                     notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                    # In staging/prod client cluster use webhook integration:
+                    notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
                 sourceRepos:
                   - git@github.com:saritasa-nest/xxx-backend.git
                   - git@github.com:saritasa-nest/xxx-frontend.git
@@ -572,10 +586,13 @@ spec:
                 namespace: xxx-dev
                 notifications:
                   annotations:
+                    # In rocks/cloud cluster use slack-token integration:
                     notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                    # In staging/prod client cluster use webhook integration:
+                    notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
               mailList: xxx@saritasa.com
               devopsMailList: devops+xxx@saritasa.com
               jiraURL: https://saritasa.atlassian.net/browse/xxx
@@ -655,10 +672,13 @@ spec:
                   - argo-cd
                 notifications:
                   annotations:
+                    # In rocks/cloud cluster use slack-token integration:
                     notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                    # In staging/prod client cluster use webhook integration:
+                    notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
               mailList: xxx@saritasa.com
               devopsMailList: devops+xxx@saritasa.com
               jiraURL: https://saritasa.atlassian.net/browse/xxx
@@ -736,10 +756,13 @@ spec:
                   - argo-cd
                 notifications:
                   annotations:
+                    # In rocks/cloud cluster use slack-token integration:
                     notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                    # In staging/prod client cluster use webhook integration:
+                    notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
               mailList: xxx@saritasa.com
               devopsMailList: devops+xxx@saritasa.com
               jiraURL: https://saritasa.atlassian.net/browse/xxx
@@ -817,10 +840,13 @@ spec:
                 namespace: xxx-dev
                 notifications:
                   annotations:
+                    # In rocks/cloud cluster use slack-token integration:
                     notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                    # In staging/prod client cluster use webhook integration:
+                    notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
               mailList: xxx@saritasa.com
               devopsMailList: devops+xxx@saritasa.com
               jiraURL: https://saritasa.atlassian.net/browse/xxx
@@ -898,10 +924,13 @@ spec:
                 namespace: xxx-dev
                 notifications:
                   annotations:
+                    # In rocks/cloud cluster use slack-token integration:
                     notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                    # In staging/prod client cluster use webhook integration:
+                    notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
               mailList: xxx@saritasa.com
               devopsMailList: devops+xxx@saritasa.com
               jiraURL: https://saritasa.atlassian.net/browse/xxx
@@ -980,10 +1009,13 @@ spec:
                 namespace: xxx
                 notifications:
                   annotations:
+                    # In rocks/cloud cluster use slack-token integration:
                     notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                    # In staging/prod client cluster use webhook integration:
+                    notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
                 sourceRepos:
                   - https://charts.bitnami.com/bitnami
               mailList: xxx@saritasa.com
@@ -1060,10 +1092,13 @@ spec:
                 namespace: xxx
                 notifications:
                   annotations:
+                    # In rocks/cloud cluster use slack-token integration:
                     notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                    # In staging/prod client cluster use webhook integration:
+                    notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
                 sourceRepos:
                   - https://charts.bitnami.com/bitnami
               mailList: xxx@saritasa.com
@@ -1137,10 +1172,13 @@ spec:
                 namespace: xxx
                 notifications:
                   annotations:
+                    # In rocks/cloud cluster use slack-token integration:
                     notifications.argoproj.io/subscribe.on-health-degraded.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-failed.slack: project-xxx-ci; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-xxx; project-xxx-alarms
                     notifications.argoproj.io/subscribe.on-deployed.slack: project-xxx-ci
+                    # In staging/prod client cluster use webhook integration:
+                    notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
                 sourceRepos:
                   - https://charts.bitnami.com/bitnami
                   - git@github.com:saritasa-nest/xxx-kubernetes-aws.git

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 0.2.12](https://img.shields.io/badge/Version-0.2.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
+![Version: 0.2.13](https://img.shields.io/badge/Version-0.2.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-apps/values-test.yaml
+++ b/charts/tekton-apps/values-test.yaml
@@ -31,10 +31,13 @@ apps:
       namespace: staging
       notifications:
         annotations:
+          # In rocks/cloud cluster use slack-token integration:
           notifications.argoproj.io/subscribe.on-health-degraded.slack: project-nmbl; project-nmbl-alarms
           notifications.argoproj.io/subscribe.on-sync-failed.slack: project-nmbl-ci; project-nmbl-alarms
           notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: project-nmbl; project-nmbl-alarms
           notifications.argoproj.io/subscribe.on-deployed.slack: project-nmbl-ci
+          # In staging/prod client cluster use webhook integration:
+          notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
       syncWave: 200
     mailList: nmbl@saritasa.com
     devopsMailList: devops+nmbl@saritasa.com


### PR DESCRIPTION
[TASK](https://saritasa.atlassian.net/browse/SD-556)

Related to https://github.com/saritasa-nest/saritasa-rocks-kubernetes-aws/pull/209 and https://github.com/saritasa-nest/saritasa-devops-boilerplates/pull/149

Added a webhook integration for argocd notifications


For rocks/cloud cluster keep adding notifications in tekton-apps AppProject as:

```yaml
notifications:
  annotations:
    notifications.argoproj.io/subscribe.on-health-degraded.slack: camp-python-2023; camp-python-2023-alarms
    notifications.argoproj.io/subscribe.on-sync-failed.slack: camp-python-2023-ci; camp-python-2023-alarms
    notifications.argoproj.io/subscribe.on-sync-status-unknown.slack: camp-python-2023; camp-python-2023-alarms
    notifications.argoproj.io/subscribe.on-deployed.slack: camp-python-2023-ci; camp-python-2023-alarms
```

For staging/prod client clusters:
```yaml
notifications:
  annotations:
    notifications.argoproj.io/subscribe.on-health-degraded.project-webhook: enabled
```
to use webhooks instead of slack-token



Applied in CCF-CCL staging: https://github.com/saritasa-nest/ccf-ccl-kubernetes-aws/pull/73


(Helm chart version not modified because only docs changed)