### PR TITLE
feat: adding configuration for saritasa-mergeable application

### DIFF
--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -29,8 +29,8 @@ mergeable:
     validate:
       - do: approvals
         min:
-          count: 2
-          message: 'At minimum 2 people are required to review this PR before merging'
+          count: 6
+          message: 'At minimum 6 people are required to review this PR before merging'
         block:
           changes_requested: true
           message: 'You have open changes requested from the reviewers'

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -1,0 +1,70 @@
+version: 2
+mergeable:
+  # Title must begin with "doc:", "feat:", "fix:" and exclude "wip"
+  - when: pull_request.*
+    name: 'Title check'
+    validate:
+      - do: title
+        must_exclude:
+         regex: '\bwip\b'
+         regex_flag: 'i' # case-insensitive (it is a default, to disable use 'none')
+         message: 'Title must exclude "wip"'
+        begins_with:
+          match: ['doc:','feat:','fix:']
+          message: 'Title must begin with "doc:", "feat:", or "fix:"'
+
+  # "wip" label must be missing
+  - when: pull_request.*
+    name: 'Label check'
+    validate:
+      - do: label
+        must_exclude:
+          regex: '\bwip\b'
+          regex_flag: 'i' # case-insensitive (it is a default, to disable use 'none')
+          message: 'Merging is not allowed if "wip" or "WIP" labels are present'
+
+  # Requires at least two approvals
+  - when: pull_request.*, pull_request_review.*
+    name: 'Approvals check'
+    validate:
+      - do: approvals
+        min:
+          count: 2
+          message: 'At minimum 2 people are required to review this PR before merging'
+        block:
+          changes_requested: true
+          message: 'You have open changes requested from the reviewers'
+        required:
+          reviewers: ['roman-mightydevops', 'kseniyashaydurova']
+
+  # CHANGELOG.md is required in the PR
+  - when: pull_request.*
+    name: 'Сhecking for the presence of the CHANGELOG.md file'
+    validate:
+      - do: changeset
+        no_empty:
+          enabled: true
+          message: 'empty'
+        must_include:
+          regex: 'CHANGELOG.md'
+          message: 'CHANGELOG.md with details must be present in every PR'
+
+  # Description of the PR must not be empty, must begin with a summary
+  # and contain a link to JIRA and must not include "DO NOT MERGE"
+  - when: pull_request.*, pull_request_review.*
+    name: 'Description check'
+    validate:
+      - do: description
+        no_empty:
+          enabled: true # Cannot be empty when true.
+          message: 'PR should have a proper summary description'
+        must_include:
+          regex: 'https://saritasa.atlassian.net/browse/[A-Z][A-Z0-9]+-\d+'
+          message: 'The description must contain a link to the JIRA task'
+        must_exclude:
+          regex: 'DO NOT MERGE'
+          regex_flag: 'i' # case-insensitive (it is a default, to disable use 'none')
+          message: 'The description should not contain "DO NOT MERGE"'
+        begins_with:
+          match: '### Summary'
+          message: 'PR Description should start with the title Summary'

--- a/.github/mergeable.yml
+++ b/.github/mergeable.yml
@@ -29,13 +29,13 @@ mergeable:
     validate:
       - do: approvals
         min:
-          count: 6
-          message: 'At minimum 6 people are required to review this PR before merging'
+          count: 4
+          message: 'At minimum 4 people are required to review this PR before merging'
         block:
           changes_requested: true
           message: 'You have open changes requested from the reviewers'
         required:
-          reviewers: ['roman-mightydevops', 'kseniyashaydurova']
+          reviewers: ['dmitry-mightydevops', 'kseniyashaydurova', 'luciano-buono']
 
   # CHANGELOG.md is required in the PR
   - when: pull_request.*

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,8 @@
+# Changelog
+
+## 2023-10-27
+
+[prod]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/99)
+- Added GitHub mergeable bot for checking PR  version `0.2.0`


### PR DESCRIPTION
### Summary

jira: https://saritasa.atlassian.net/browse/SD-717

Mergeable automates GitHub workflow

You can configure it in the .github repository, in the file .github/mergeable.yml
We use the [following recipes](https://github.com/saritasa-nest/saritasa-devops-helm-charts/blob/feature/add-github-bot-mergeable/.github/mergeable.yml)

Descriptions of all configuration blocks can be found [here](https://github.com/saritasa-nest/saritasa-rocks-kubernetes-aws/pull/239)
