### PR TITLE
feat: add `grafana-dashboards` helm chart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,11 +1,19 @@
 # Changelog
 
+## 2024-01-16
+
+[prod]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/105)
+- Added helm chart for grafana dashboards (only ingress-nginx dashboards)
+
 ## 2023-12-26
 
 [prod]
 
 - [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/100)
 - Added push image to registry with additional tag `latest`
+
 ## 2023-12-22
 
 [prod]

--- a/charts/grafana-dashboards/.helmignore
+++ b/charts/grafana-dashboards/.helmignore
@@ -1,0 +1,23 @@
+# Patterns to ignore when building packages.
+# This supports shell glob matching, relative path matching, and
+# negation (prefixed with !). Only one pattern per line.
+.DS_Store
+# Common VCS dirs
+.git/
+.gitignore
+.bzr/
+.bzrignore
+.hg/
+.hgignore
+.svn/
+# Common backup files
+*.swp
+*.bak
+*.tmp
+*.orig
+*~
+# Various IDEs
+.project
+.idea/
+*.tmproj
+.vscode/

--- a/charts/grafana-dashboards/Chart.yaml
+++ b/charts/grafana-dashboards/Chart.yaml
@@ -1,0 +1,17 @@
+apiVersion: v2
+name: grafana-dashboards
+
+type: application
+
+# This is the chart version. This version number should be incremented each time you make changes
+# to the chart and its templates, including the app version.
+# Versions are expected to follow Semantic Versioning (https://semver.org/)
+version: 0.0.1
+
+maintainers:
+  - url: https://www.saritasa.com/
+    name: Saritasa
+    email: nospam@saritasa.com
+
+description: |
+  A Helm chart for provisioning grafana dashboards

--- a/charts/grafana-dashboards/Chart.yaml
+++ b/charts/grafana-dashboards/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.1
+version: 0.0.2
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/grafana-dashboards/README.md
+++ b/charts/grafana-dashboards/README.md
@@ -31,7 +31,7 @@ grafana-dashboards
 
 ## `chart.version`
 
-![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 0.0.2](https://img.shields.io/badge/Version-0.0.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 
@@ -52,4 +52,5 @@ A Helm chart for provisioning grafana dashboards
 | ingressNginx.enabled | bool | `true` |  |
 | ingressNginx.namespace | string | `"grafana"` |  |
 | ingressNginx.requestHandlingPerformance | bool | `true` | provision `Request Handling Performance` dashboard |
+| ingressNginx.targetDirectory | string | `"/var/lib/grafana/dashboards/ingress-nginx/"` |  |
 

--- a/charts/grafana-dashboards/README.md
+++ b/charts/grafana-dashboards/README.md
@@ -1,0 +1,55 @@
+
+# grafana-dashboards
+
+## `license`
+```
+          ,-.
+ ,     ,-.   ,-.
+/ \   (   )-(   )
+\ |  ,.>-(   )-<
+ \|,' (   )-(   )
+  Y ___`-'   `-'
+  |/__/   `-'
+  |
+  |
+  |    -hi-
+__|_____________
+
+/* Copyright (C) Saritasa,LLC - All Rights Reserved
+ * Unauthorized copying of this file, via any medium is strictly prohibited
+ * Proprietary and confidential
+ * Written by Saritasa Devops Team, April 2022
+ */
+
+```
+
+## `chart.deprecationWarning`
+
+## `chart.name`
+
+grafana-dashboards
+
+## `chart.version`
+
+![Version: 0.0.1](https://img.shields.io/badge/Version-0.0.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+
+## Maintainers
+
+| Name | Email | Url |
+| ---- | ------ | --- |
+| Saritasa | <nospam@saritasa.com> | <https://www.saritasa.com/> |
+
+## `chart.description`
+
+A Helm chart for provisioning grafana dashboards
+
+## `chart.valuesTable`
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| ingressNginx.controller | bool | `true` | provision `NGINX Ingress controller` dashboard |
+| ingressNginx.controllerLoki | bool | `true` | provision `NGINX Ingress controller - Loki` dashboard |
+| ingressNginx.enabled | bool | `true` |  |
+| ingressNginx.namespace | string | `"grafana"` |  |
+| ingressNginx.requestHandlingPerformance | bool | `true` | provision `Request Handling Performance` dashboard |
+

--- a/charts/grafana-dashboards/README.md.gotmpl
+++ b/charts/grafana-dashboards/README.md.gotmpl
@@ -1,0 +1,27 @@
+{{ template "chart.header" . }}
+
+## `license`
+{{ template "license" . }}
+
+## `chart.deprecationWarning`
+{{ template "chart.deprecationWarning" . }}
+
+## `chart.name`
+
+{{ template "chart.name" . }}
+
+## `chart.version`
+
+{{ template "chart.badgesSection" . }}
+
+{{ template "chart.maintainersSection" . }}
+
+## `chart.description`
+
+{{ template "chart.description" . }}
+
+## `chart.valuesTable`
+
+{{ template "chart.valuesTable" . }}
+
+{{ template "helm-docs.versionFooter" . }}

--- a/charts/grafana-dashboards/templates/ingress-nginx/controller-loki.yaml
+++ b/charts/grafana-dashboards/templates/ingress-nginx/controller-loki.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Values.ingressNginx.namespace }}
   labels:
     grafana_dashboard: "1"
+  annotations:
+    k8s-sidecar-target-directory: {{ .Values.ingressNginx.targetDirectory }}
 data:
   ingress-nginx-controller-loki.json: |
     {

--- a/charts/grafana-dashboards/templates/ingress-nginx/controller-loki.yaml
+++ b/charts/grafana-dashboards/templates/ingress-nginx/controller-loki.yaml
@@ -1,0 +1,2017 @@
+{{- if and .Values.ingressNginx.enabled .Values.ingressNginx.controllerLoki -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ingress-nginx-controller-loki
+  namespace: {{ .Values.ingressNginx.namespace }}
+  labels:
+    grafana_dashboard: "1"
+data:
+  ingress-nginx-controller-loki.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "Stats from nginx logs",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "gnetId": 12559,
+      "graphTooltip": 0,
+      "id": 10,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "collapsed": false,
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 0
+          },
+          "id": 24,
+          "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "KPI's",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "purple",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 5,
+            "x": 0,
+            "y": 1
+          },
+          "hideTimeOverride": false,
+          "id": 4,
+          "maxDataPoints": 300,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "sum"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "sum by(host) (count_over_time({job=~\"$job\", instance=~\"$instance\"}[$__interval]))  ",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "timeFrom": "24h",
+          "title": "Total requests  ",
+          "transformations": [],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "percentage",
+                "steps": [
+                  {
+                    "color": "rgba(110, 157, 228, 0.76)",
+                    "value": null
+                  },
+                  {
+                    "color": "rgba(73, 124, 202, 1)",
+                    "value": 20
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 7,
+            "x": 5,
+            "y": 1
+          },
+          "id": 5,
+          "maxDataPoints": 20,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "sum"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "sum by (status) (count_over_time({job=~\"$job\", instance=~\"$instance\"} | json |  __error__=\"\" [$__interval]))",
+              "instant": false,
+              "legendFormat": {{- "HTTP Status: {{ status }}" | quote -}},
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "title": "Requests per status code",
+          "transformations": [],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 0,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "semi-dark-orange",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 12,
+            "y": 1
+          },
+          "id": 30,
+          "maxDataPoints": 1,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "sum"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "sum by (app) (bytes_over_time({job=~\"$job\", instance=~\"$instance\"}[$__interval]))",
+              "instant": true,
+              "legendFormat": "$label_value",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "NGINX logs in bytes",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "purple",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 15,
+            "y": 1
+          },
+          "id": 8,
+          "maxDataPoints": 1,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "sum"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "sum by (host) (sum_over_time({job=~\"$job\", instance=~\"$instance\"} | json | unwrap body_bytes_sent |  __error__=\"\" [$__interval]))",
+              "instant": true,
+              "legendFormat": "Bytes sent",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "Total Bytes Sent",
+          "transformations": [],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "purple",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 6,
+            "x": 18,
+            "y": 1
+          },
+          "hideTimeOverride": true,
+          "id": 18,
+          "interval": "10m",
+          "links": [],
+          "maxDataPoints": 1,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "last"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "sum(count_over_time(({job=~\"$job\", instance=~\"$instance\"} |= \"Googlebot\")[$__interval])) / (sum(count_over_time(({job=~\"$job\", instance=~\"$instance\"} != \"Googlebot\")[$__interval])) / 100)",
+              "instant": true,
+              "legendFormat": "",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "timeFrom": "1h",
+          "title": "% of requests by Googlebot",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "purple",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 5,
+            "x": 0,
+            "y": 5
+          },
+          "id": 22,
+          "interval": "5m",
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "mean"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "count(sum by (remote_addr) (count_over_time({job=~\"$job\", instance=~\"$instance\"} | json |  __error__=\"\" [$__interval])))",
+              "instant": true,
+              "legendFormat": "",
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "timeFrom": "5m",
+          "title": "Realtime visitors ",
+          "transformations": [],
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 0,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "semi-dark-orange",
+                    "value": null
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 12,
+            "y": 5
+          },
+          "id": 31,
+          "maxDataPoints": 1,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "auto",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "sum"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "auto",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "sum by (app) (count_over_time({job=~\"$job\", instance=~\"$instance\"}[$__interval]))",
+              "instant": true,
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "title": "# NGINX log lines",
+          "type": "stat"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "decimals": 1,
+              "mappings": [],
+              "max": 100,
+              "min": 0,
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "purple",
+                    "value": null
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "percent"
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 4,
+            "w": 3,
+            "x": 15,
+            "y": 5
+          },
+          "hideTimeOverride": true,
+          "id": 19,
+          "links": [],
+          "maxDataPoints": 1,
+          "options": {
+            "colorMode": "background",
+            "graphMode": "none",
+            "justifyMode": "center",
+            "orientation": "auto",
+            "reduceOptions": {
+              "calcs": [
+                "max"
+              ],
+              "fields": "",
+              "values": false
+            },
+            "text": {},
+            "textMode": "value",
+            "wideLayout": true
+          },
+          "pluginVersion": "10.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "sum(count_over_time({job=~\"$job\", instance=~\"$instance\"} | json | status >= 500 |__error__=\"\"[$__interval])) / (sum(count_over_time({job=~\"$job\", instance=~\"$instance\"} | json | __error__=\"\"[$__interval]))/ 100)",
+              "instant": false,
+              "legendFormat": "",
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "timeFrom": "1h",
+          "title": "% of 5xx requests ",
+          "type": "stat"
+        },
+        {
+          "circleMaxSize": "50",
+          "circleMinSize": "15",
+          "colors": [
+            "#96D98D",
+            "#73BF69",
+            "#56A64B"
+          ],
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "esMetric": "Count",
+          "gridPos": {
+            "h": 11,
+            "w": 12,
+            "x": 0,
+            "y": 9
+          },
+          "hideEmpty": false,
+          "hideZero": false,
+          "id": 14,
+          "initialZoom": "2",
+          "locationData": "countries",
+          "mapCenter": "(0°, 0°)",
+          "mapCenterLatitude": 0,
+          "mapCenterLongitude": 0,
+          "maxDataPoints": 1,
+          "mouseWheelZoom": false,
+          "pluginVersion": "7.4.0",
+          "showLegend": true,
+          "stickyLabels": true,
+          "tableQueryOptions": {
+            "geohashField": "geohash",
+            "latitudeField": "latitude",
+            "longitudeField": "longitude",
+            "metricField": "metric",
+            "queryType": "geohash"
+          },
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "sum by (geoip_country_code) (count_over_time({job=~\"$job\", instance=~\"$instance\"} | json | geoip_country_code != \"\" | __error__=\"\" [$__interval]))",
+              "instant": false,
+              "legendFormat": {{- "{{ geoip_country_code }}" | quote -}},
+              "range": true,
+              "refId": "A"
+            }
+          ],
+          "thresholds": "5,10",
+          "title": "Requests per Country",
+          "transformations": [],
+          "type": "grafana-worldmap-panel",
+          "unitPlural": "",
+          "unitSingle": "",
+          "valueName": "total"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "continuous-BlPu"
+              },
+              "custom": {
+                "align": "center",
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false,
+                "inspect": false
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "CN": {
+                      "color": "transparent",
+                      "index": 4,
+                      "text": "🇨🇳CN"
+                    },
+                    "DE": {
+                      "color": "transparent",
+                      "index": 2,
+                      "text": "🇩🇪DE"
+                    },
+                    "FR": {
+                      "color": "transparent",
+                      "index": 3,
+                      "text": "🇫🇷FR"
+                    },
+                    "GB": {
+                      "color": "transparent",
+                      "index": 7,
+                      "text": "🇬🇧GB"
+                    },
+                    "IN": {
+                      "color": "transparent",
+                      "index": 5,
+                      "text": "🇮🇳IN"
+                    },
+                    "IT": {
+                      "color": "transparent",
+                      "index": 6,
+                      "text": "🇮🇹IT"
+                    },
+                    "NL": {
+                      "color": "transparent",
+                      "index": 1,
+                      "text": "🇳🇱NL"
+                    },
+                    "US": {
+                      "color": "transparent",
+                      "index": 0,
+                      "text": "🇺🇸 US"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "transparent",
+                    "value": null
+                  }
+                ]
+              }
+            },
+            "overrides": []
+          },
+          "gridPos": {
+            "h": 11,
+            "w": 3,
+            "x": 12,
+            "y": 9
+          },
+          "hideTimeOverride": true,
+          "id": 32,
+          "maxDataPoints": 1,
+          "options": {
+            "cellHeight": "sm",
+            "footer": {
+              "countRows": false,
+              "fields": "",
+              "reducer": [
+                "sum"
+              ],
+              "show": false
+            },
+            "showHeader": false,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Requests"
+              }
+            ]
+          },
+          "pluginVersion": "10.2.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "topk(10, sum by (geoip_country_code) (count_over_time({job=~\"$job\", instance=~\"$instance\"} | json | geoip_country_code != \"\" and  __error__=\"\" [$__interval])))",
+              "instant": true,
+              "legendFormat": {{- "{{ remote_addr }}" | quote -}},
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "timeFrom": "15m",
+          "title": "Top Countries",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Field": false,
+                  "Time": true,
+                  "Value #A": true
+                },
+                "indexByName": {
+                  "Time": 0,
+                  "Value #A": 3,
+                  "geoip_country_code": 2,
+                  "remote_addr": 1
+                },
+                "renameByName": {
+                  "Field": "IP Address",
+                  "Total": "Requests",
+                  "Value #A": "Requests",
+                  "geoip_country_code": "Country",
+                  "remote_addr": "IP Address "
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "gridPos": {
+            "h": 11,
+            "w": 9,
+            "x": 15,
+            "y": 9
+          },
+          "id": 11,
+          "options": {
+            "dedupStrategy": "signature",
+            "enableLogDetails": false,
+            "prettifyLogMessage": false,
+            "showCommonLabels": false,
+            "showLabels": false,
+            "showTime": false,
+            "sortOrder": "Descending",
+            "wrapLogMessage": false
+          },
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "{job=~\"$job\", instance=~\"$instance\"} | json | upstream_namespace!~\"grafana|tekton-pipelines\" | line_format \"➡️ {{.upstream_namespace}} {{.request_method}} {{.request_uri}} with HTTP status: {{.status}}\"",
+              "legendFormat": "",
+              "refId": "A"
+            }
+          ],
+          "title": "Recent requests",
+          "type": "logs"
+        },
+        {
+          "collapsed": false,
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 20
+          },
+          "id": 26,
+          "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Request statistics over time",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 100,
+                "gradientMode": "hue",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "log": 2,
+                  "type": "log"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "area"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "#EAB839",
+                    "value": 0.2
+                  },
+                  {
+                    "color": "red",
+                    "value": 0.3
+                  }
+                ]
+              },
+              "unit": "s"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "95th percentile"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "max latency"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "super-light-blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "max latency"
+                },
+                "properties": [
+                  {
+                    "id": "custom.fillOpacity",
+                    "value": 30
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 0,
+            "y": 21
+          },
+          "id": 16,
+          "maxDataPoints": 50,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.0.0-beta3",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "quantile_over_time(0.95,{job=~\"$job\", instance=~\"$instance\"} | json | upstream_namespace!~\"grafana|argo-cd|tekton-pipelines\" | unwrap request_time |  __error__=\"\"  [$__interval]) by (host)",
+              "legendFormat": "95th percentile",
+              "refId": "C"
+            },
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "max by (host) (max_over_time({job=~\"$job\", instance=~\"$instance\"} | json | upstream_namespace!~\"grafana|argo-cd|tekton-pipelines\" | unwrap request_time |  __error__=\"\"  [$__interval]))",
+              "legendFormat": "max latency",
+              "refId": "D"
+            }
+          ],
+          "title": "95th percentile of Request Time",
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 39,
+                "gradientMode": "hue",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "log": 2,
+                  "type": "log"
+                },
+                "showPoints": "never",
+                "spanNulls": true,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "decimals": 0,
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "short"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "HTTP Status 500"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "{statuscode=\"200\"} 200"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "green",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "{statuscode=\"404\"} 404"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-purple",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "{statuscode=\"500\"} 500"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "dark-red",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "HTTP Status 404"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "light-orange",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "HTTP Status 301"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "light-blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "HTTP Status 200"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "semi-dark-blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 8,
+            "y": 21
+          },
+          "id": 2,
+          "maxDataPoints": 50,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.0.0-beta3",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "sum by (status) (count_over_time({job=~\"$job\", instance=~\"$instance\"} | json |  __error__=\"\" [$__interval]))",
+              "legendFormat": {{- "HTTP Status {{ status }}" | quote -}},
+              "refId": "A"
+            }
+          ],
+          "title": "HTTP status codes over time",
+          "transformations": [
+            {
+              "id": "filterFieldsByName",
+              "options": {
+                "include": {
+                  "names": [
+                    "Time",
+                    "HTTP Status 200",
+                    "HTTP Status 301",
+                    "HTTP Status 304",
+                    "HTTP Status 404",
+                    "HTTP Status 406",
+                    "HTTP Status 500"
+                  ]
+                }
+              }
+            }
+          ],
+          "type": "timeseries"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "palette-classic"
+              },
+              "custom": {
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 100,
+                "gradientMode": "hue",
+                "hideFrom": {
+                  "legend": false,
+                  "tooltip": false,
+                  "viz": false
+                },
+                "lineInterpolation": "smooth",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                  "type": "linear"
+                },
+                "showPoints": "never",
+                "spanNulls": false,
+                "stacking": {
+                  "group": "A",
+                  "mode": "none"
+                },
+                "thresholdsStyle": {
+                  "mode": "off"
+                }
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              },
+              "unit": "decbytes"
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Bytes sent"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "light-blue",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "appfelstrudel"
+                },
+                "properties": [
+                  {
+                    "id": "color",
+                    "value": {
+                      "fixedColor": "yellow",
+                      "mode": "fixed"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 9,
+            "w": 8,
+            "x": 16,
+            "y": 21
+          },
+          "id": 9,
+          "maxDataPoints": 50,
+          "options": {
+            "legend": {
+              "calcs": [],
+              "displayMode": "list",
+              "placement": "bottom",
+              "showLegend": true
+            },
+            "tooltip": {
+              "mode": "single"
+            }
+          },
+          "pluginVersion": "8.0.0-beta3",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "sum by (host) (sum_over_time({job=~\"$job\", instance=~\"$instance\"} | json | status=200 | unwrap body_bytes_sent |  __error__=\"\" [$__interval]))",
+              "legendFormat": "Bytes sent",
+              "refId": "A"
+            }
+          ],
+          "title": "Bytes Sent",
+          "transformations": [],
+          "type": "timeseries"
+        },
+        {
+          "collapsed": false,
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "gridPos": {
+            "h": 1,
+            "w": 24,
+            "x": 0,
+            "y": 30
+          },
+          "id": 28,
+          "panels": [],
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "refId": "A"
+            }
+          ],
+          "title": "Acquisition and Behaviour",
+          "type": "row"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Requests"
+                },
+                "properties": [
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "mode": "gradient",
+                      "type": "gauge"
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-BlPu"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Requests"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 300
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 9,
+            "x": 0,
+            "y": 31
+          },
+          "id": 6,
+          "maxDataPoints": 1,
+          "options": {
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Requests"
+              }
+            ]
+          },
+          "pluginVersion": "8.1.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "topk(10, sum by (http_referer) (count_over_time({job=~\"$job\", instance=~\"$instance\"} | json | upstream_namespace!~\"grafana|argo-cd|tekton-pipelines\" |  http_referer != \"\" and http_referer !~ \".*?$host.*?\" and http_referer !~ \".*?\\\\*\\\\*\\\\*.*?\" | __error__=\"\" [15m])))",
+              "instant": true,
+              "legendFormat": {{- "{{ http_referer }}" | quote -}},
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "timeFrom": "15m",
+          "title": "Top 10 HTTP Referers",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Field": "Referer",
+                  "Total": "Requests",
+                  "Value #A": "Requests",
+                  "http_referer": "HTTP Referrer"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Requests"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 300
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "mode": "gradient",
+                      "type": "gauge"
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-BlPu"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 6,
+            "w": 15,
+            "x": 9,
+            "y": 31
+          },
+          "id": 7,
+          "maxDataPoints": 1,
+          "options": {
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Requests"
+              }
+            ]
+          },
+          "pluginVersion": "8.1.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "topk(10, sum by (http_user_agent) (count_over_time({job=~\"$job\", instance=~\"$instance\"} | json |  __error__=\"\" [15m])))",
+              "instant": true,
+              "legendFormat": {{- "{{ http_user_agent}}" | quote -}},
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "timeFrom": "15m",
+          "title": "Top 10 User Agents",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Field": false,
+                  "Time": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Field": "Agent",
+                  "Total": "Requests",
+                  "Value #A": "Requests",
+                  "http_user_agent": "User agent"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false
+              },
+              "mappings": [
+                {
+                  "options": {
+                    "NL": {
+                      "index": 1,
+                      "text": "🇳🇱"
+                    },
+                    "US": {
+                      "index": 0,
+                      "text": "🇺🇸"
+                    }
+                  },
+                  "type": "value"
+                }
+              ],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Requests"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 300
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "mode": "gradient",
+                      "type": "gauge"
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-BlPu"
+                    }
+                  }
+                ]
+              },
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Country"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 74
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 9,
+            "x": 0,
+            "y": 37
+          },
+          "id": 3,
+          "maxDataPoints": 1,
+          "options": {
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Requests"
+              }
+            ]
+          },
+          "pluginVersion": "8.1.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "topk(10, sum by (remote_addr, geoip_country_code) (count_over_time({job=~\"$job\", instance=~\"$instance\"} | json |  __error__=\"\" [15m])))",
+              "instant": true,
+              "legendFormat": {{- "{{ remote_addr}}" | quote -}},
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "timeFrom": "15m",
+          "title": "Top 10 visitor IPs",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Field": false,
+                  "Time": true
+                },
+                "indexByName": {
+                  "Time": 0,
+                  "Value #A": 3,
+                  "geoip_country_code": 2,
+                  "remote_addr": 1
+                },
+                "renameByName": {
+                  "Field": "IP Address",
+                  "Total": "Requests",
+                  "Value #A": "Requests",
+                  "geoip_country_code": "Country",
+                  "remote_addr": "IP Address "
+                }
+              }
+            }
+          ],
+          "type": "table"
+        },
+        {
+          "datasource": {
+            "uid": "$datasource"
+          },
+          "description": "",
+          "fieldConfig": {
+            "defaults": {
+              "color": {
+                "mode": "thresholds"
+              },
+              "custom": {
+                "cellOptions": {
+                  "type": "auto"
+                },
+                "filterable": false
+              },
+              "mappings": [],
+              "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                  {
+                    "color": "green"
+                  },
+                  {
+                    "color": "red",
+                    "value": 80
+                  }
+                ]
+              }
+            },
+            "overrides": [
+              {
+                "matcher": {
+                  "id": "byName",
+                  "options": "Requests"
+                },
+                "properties": [
+                  {
+                    "id": "custom.width",
+                    "value": 300
+                  },
+                  {
+                    "id": "custom.cellOptions",
+                    "value": {
+                      "mode": "gradient",
+                      "type": "gauge"
+                    }
+                  },
+                  {
+                    "id": "color",
+                    "value": {
+                      "mode": "continuous-BlPu"
+                    }
+                  }
+                ]
+              }
+            ]
+          },
+          "gridPos": {
+            "h": 8,
+            "w": 15,
+            "x": 9,
+            "y": 37
+          },
+          "id": 12,
+          "maxDataPoints": 1,
+          "options": {
+            "showHeader": true,
+            "sortBy": [
+              {
+                "desc": true,
+                "displayName": "Requests"
+              }
+            ]
+          },
+          "pluginVersion": "8.1.2",
+          "targets": [
+            {
+              "datasource": {
+                "uid": "$datasource"
+              },
+              "expr": "topk(10, sum by (request_uri) (count_over_time({job=~\"$job\", instance=~\"$instance\"} !~ `\\.ico|\\.svg|\\.css|\\.png|\\.txt|\\.js|\\.xml` | json | upstream_namespace!~\"grafana|argo-cd|tekton-pipelines\" | status = 200 and request_uri != \"/\" | __error__=\"\" [15m])))",
+              "instant": true,
+              "legendFormat": {{- "{{request_uri}}" | quote -}},
+              "range": false,
+              "refId": "A"
+            }
+          ],
+          "timeFrom": "15m",
+          "title": "Top 10 Requested Pages",
+          "transformations": [
+            {
+              "id": "organize",
+              "options": {
+                "excludeByName": {
+                  "Time": true
+                },
+                "indexByName": {},
+                "renameByName": {
+                  "Field": "Page",
+                  "Time": "",
+                  "Total": "",
+                  "Value #A": "Requests",
+                  "request_uri": "Path"
+                }
+              }
+            }
+          ],
+          "type": "table"
+        }
+      ],
+      "refresh": "",
+      "schemaVersion": 38,
+      "tags": [
+        "nginx"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "Loki",
+              "value": "loki"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "Datasource",
+            "multi": false,
+            "name": "datasource",
+            "options": [],
+            "query": "loki",
+            "queryValue": "",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "job",
+              "value": "job"
+            },
+            "datasource": {
+              "type": "loki",
+              "uid": "$datasource"
+            },
+            "definition": "label_names()",
+            "hide": 0,
+            "includeAll": false,
+            "label": "Label Name",
+            "multi": false,
+            "name": "label_name",
+            "options": [],
+            "query": "label_names()",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "current": {
+              "selected": true,
+              "text": [
+                "ingress-nginx/ingress-nginx"
+              ],
+              "value": [
+                "ingress-nginx/ingress-nginx"
+              ]
+            },
+            "datasource": {
+              "type": "loki",
+              "uid": "$datasource"
+            },
+            "definition": "label_values($label_name)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Label Value",
+            "multi": true,
+            "name": "label_value",
+            "options": [],
+            "query": "label_values($label_name)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 1,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "type": "loki",
+              "uid": "$datasource"
+            },
+            "definition": "label_values({$label_name=~\"$label_value\"}, job)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Job",
+            "multi": true,
+            "name": "job",
+            "options": [],
+            "query": "label_values({$label_name=~\"$label_value\"}, job)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          },
+          {
+            "current": {
+              "selected": true,
+              "text": [
+                "All"
+              ],
+              "value": [
+                "$__all"
+              ]
+            },
+            "datasource": {
+              "type": "loki",
+              "uid": "$datasource"
+            },
+            "definition": "label_values({$label_name=~\"$label_value\"}, instance)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Instance",
+            "multi": true,
+            "name": "instance",
+            "options": [],
+            "query": "label_values({$label_name=~\"$label_value\"}, instance)",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-5m",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "10s",
+          "30s",
+          "1m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ]
+      },
+      "timezone": "",
+      "title": "NGINX Ingress controller - Loki",
+      "uid": "8y2WIeHnz",
+      "version": 1,
+      "weekStart": ""
+    }
+{{- end }}

--- a/charts/grafana-dashboards/templates/ingress-nginx/controller.yaml
+++ b/charts/grafana-dashboards/templates/ingress-nginx/controller.yaml
@@ -1,0 +1,1743 @@
+{{- if and .Values.ingressNginx.enabled .Values.ingressNginx.controller -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ingress-nginx-controller
+  namespace: {{ .Values.ingressNginx.namespace }}
+  labels:
+    grafana_dashboard: "1"
+data:
+  ingress-nginx-controller.json: |
+    {
+    "annotations": {
+        "list": [
+        {
+            "builtIn": 1,
+            "datasource": {
+            "type": "datasource",
+            "uid": "grafana"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+            "limit": 100,
+            "matchAny": false,
+            "tags": [],
+            "type": "dashboard"
+            },
+            "type": "dashboard"
+        },
+        {
+            "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+            },
+            "enable": true,
+            "expr": "sum(changes(nginx_ingress_controller_config_last_reload_successful_timestamp_seconds{instance!=\"unknown\",controller_class=~\"$controller_class\",namespace=~\"$namespace\"}[30s])) by (controller_class)",
+            "hide": false,
+            "iconColor": "rgba(255, 96, 96, 1)",
+            "limit": 100,
+            "name": "Config Reloads",
+            "showIn": 0,
+            "step": "30s",
+            "tagKeys": "controller_class",
+            "tags": [],
+            "titleFormat": "Config Reloaded",
+            "type": "tags"
+        }
+        ]
+    },
+    "editable": true,
+    "fiscalYearStartMonth": 0,
+    "graphTooltip": 0,
+    "id": 8,
+    "links": [],
+    "liveNow": false,
+    "panels": [
+        {
+        "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "fixedColor": "rgb(31, 120, 193)",
+                "mode": "fixed"
+            },
+            "mappings": [
+                {
+                "options": {
+                    "match": "null",
+                    "result": {
+                    "text": "N/A"
+                    }
+                },
+                "type": "special"
+                }
+            ],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            },
+            "unit": "ops"
+            },
+            "overrides": []
+        },
+        "id": 20,
+        "links": [],
+        "maxDataPoints": 100,
+        "options": {
+            "colorMode": "none",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+            "calcs": [
+                "mean"
+            ],
+            "fields": "",
+            "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+        },
+        "pluginVersion": "10.2.2",
+        "targets": [
+            {
+            "expr": "round(sum(irate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\"}[2m])), 0.001)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "refId": "A",
+            "step": 4
+            }
+        ],
+        "title": "Controller Request Volume",
+        "type": "stat"
+        },
+        {
+        "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "fixedColor": "rgb(31, 120, 193)",
+                "mode": "fixed"
+            },
+            "mappings": [
+                {
+                "options": {
+                    "match": "null",
+                    "result": {
+                    "text": "N/A"
+                    }
+                },
+                "type": "special"
+                }
+            ],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            },
+            "unit": "none"
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 6,
+            "y": 0
+        },
+        "id": 82,
+        "links": [],
+        "maxDataPoints": 100,
+        "options": {
+            "colorMode": "none",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+            "calcs": [
+                "mean"
+            ],
+            "fields": "",
+            "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+        },
+        "pluginVersion": "10.2.2",
+        "targets": [
+            {
+            "expr": "sum(avg_over_time(nginx_ingress_controller_nginx_process_connections{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",state=\"active\"}[2m]))",
+            "format": "time_series",
+            "instant": false,
+            "intervalFactor": 1,
+            "refId": "A",
+            "step": 4
+            }
+        ],
+        "title": "Controller Connections",
+        "type": "stat"
+        },
+        {
+        "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "fixedColor": "rgb(31, 120, 193)",
+                "mode": "fixed"
+            },
+            "mappings": [
+                {
+                "options": {
+                    "match": "null",
+                    "result": {
+                    "index": 0,
+                    "text": "No traffic"
+                    }
+                },
+                "type": "special"
+                }
+            ],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "rgba(245, 54, 54, 0.9)",
+                    "value": null
+                },
+                {
+                    "color": "rgba(237, 129, 40, 0.89)",
+                    "value": 95
+                },
+                {
+                    "color": "rgba(50, 172, 45, 0.97)",
+                    "value": 99
+                }
+                ]
+            },
+            "unit": "percentunit"
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 3,
+            "w": 6,
+            "x": 12,
+            "y": 0
+        },
+        "id": 21,
+        "links": [],
+        "maxDataPoints": 100,
+        "options": {
+            "colorMode": "none",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+            "calcs": [
+                "mean"
+            ],
+            "fields": "",
+            "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+        },
+        "pluginVersion": "10.2.2",
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "sum (rate (nginx_ingress_controller_requests{controller_pod=~\"$controller\", controller_class=~\"$controller_class\", namespace=~\"$namespace\", status!~\"[4-5].*\"}[$__range]) > 0) / sum (rate (nginx_ingress_controller_requests{controller_pod=~\"$controller\", controller_class=~\"$controller_class\", namespace=~\"$namespace\"}[$__range]) > 0)",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "range": true,
+            "refId": "A",
+            "step": 4
+            }
+        ],
+        "title": "Controller Success Rate (non-4|5xx responses)",
+        "type": "stat"
+        },
+        {
+        "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "fixedColor": "rgb(31, 120, 193)",
+                "mode": "fixed"
+            },
+            "decimals": 0,
+            "mappings": [
+                {
+                "options": {
+                    "match": "null",
+                    "result": {
+                    "text": "N/A"
+                    }
+                },
+                "type": "special"
+                }
+            ],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            },
+            "unit": "none"
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 18,
+            "y": 0
+        },
+        "id": 81,
+        "links": [],
+        "maxDataPoints": 100,
+        "options": {
+            "colorMode": "none",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+            "calcs": [
+                "sum"
+            ],
+            "fields": "",
+            "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+        },
+        "pluginVersion": "10.2.2",
+        "targets": [
+            {
+            "expr": "avg(irate(nginx_ingress_controller_success{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}[1m])) * 60",
+            "format": "time_series",
+            "instant": false,
+            "intervalFactor": 1,
+            "refId": "A",
+            "step": 4
+            }
+        ],
+        "title": "Config Reloads",
+        "type": "stat"
+        },
+        {
+        "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "fixedColor": "rgb(31, 120, 193)",
+                "mode": "fixed"
+            },
+            "decimals": 0,
+            "mappings": [
+                {
+                "options": {
+                    "match": "null",
+                    "result": {
+                    "color": "green",
+                    "index": 0,
+                    "text": "OK 🥰"
+                    }
+                },
+                "type": "special"
+                }
+            ],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green",
+                    "value": null
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            },
+            "unit": "none"
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 3,
+            "w": 3,
+            "x": 21,
+            "y": 0
+        },
+        "id": 83,
+        "links": [],
+        "maxDataPoints": 100,
+        "options": {
+            "colorMode": "value",
+            "graphMode": "area",
+            "justifyMode": "auto",
+            "orientation": "horizontal",
+            "reduceOptions": {
+            "calcs": [
+                "mean"
+            ],
+            "fields": "",
+            "values": false
+            },
+            "textMode": "auto",
+            "wideLayout": true
+        },
+        "pluginVersion": "10.2.2",
+        "targets": [
+            {
+            "expr": "count(nginx_ingress_controller_config_last_reload_successful{controller_pod=~\"$controller\",controller_namespace=~\"$namespace\"} == 0)",
+            "format": "time_series",
+            "instant": true,
+            "intervalFactor": 1,
+            "refId": "A",
+            "step": 4
+            }
+        ],
+        "title": "Last Config Failed",
+        "type": "stat"
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+        },
+        "decimals": 2,
+        "editable": true,
+        "error": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 3
+        },
+        "height": "200px",
+        "hiddenSeries": false,
+        "id": 86,
+        "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": false,
+            "hideEmpty": false,
+            "hideZero": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": 300,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "10.2.2",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "repeatDirection": "h",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "round(sum(irate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (ingress), 0.001)",
+            "format": "time_series",
+            "hide": false,
+            "instant": false,
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": {{- "{{ ingress }}" | quote -}},
+            "metric": "network",
+            "refId": "A",
+            "step": 10
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Ingress Request Volume",
+        "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 2,
+            "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "format": "reqps",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "format": "Bps",
+            "logBase": 1,
+            "show": false
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {
+            "max - istio-proxy": "#890f02",
+            "max - master": "#bf1b00",
+            "max - prometheus": "#bf1b00"
+        },
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+        },
+        "decimals": 2,
+        "editable": false,
+        "error": false,
+        "fill": 0,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 3
+        },
+        "hiddenSeries": false,
+        "id": 87,
+        "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": false,
+            "hideEmpty": true,
+            "hideZero": false,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": true,
+            "sideWidth": 300,
+            "sort": "avg",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "10.2.2",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum(rate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\",ingress=~\"$ingress\",status!~\"[4-5].*\"}[2m])) by (ingress) / sum(rate(nginx_ingress_controller_requests{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (ingress)",
+            "format": "time_series",
+            "instant": false,
+            "interval": "10s",
+            "intervalFactor": 1,
+            "legendFormat": {{- "{{ ingress }}" | quote -}},
+            "metric": "container_memory_usage:sort_desc",
+            "refId": "A",
+            "step": 10
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Ingress Success Rate (non-4|5xx responses)",
+        "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 1,
+            "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "format": "percentunit",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "format": "short",
+            "logBase": 1,
+            "show": false
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {},
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+        },
+        "decimals": 2,
+        "editable": true,
+        "error": false,
+        "fill": 1,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 0,
+            "y": 10
+        },
+        "height": "200px",
+        "hiddenSeries": false,
+        "id": 32,
+        "legend": {
+            "alignAsTable": false,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": false,
+            "sideWidth": 200,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "10.2.2",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "sum (irate (nginx_ingress_controller_request_size_sum{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}[2m]))",
+            "format": "time_series",
+            "instant": false,
+            "interval": "10s",
+            "intervalFactor": 1,
+            "legendFormat": "Received",
+            "metric": "network",
+            "refId": "A",
+            "step": 10
+            },
+            {
+            "expr": "- sum (irate (nginx_ingress_controller_response_size_sum{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}[2m]))",
+            "format": "time_series",
+            "hide": false,
+            "interval": "10s",
+            "intervalFactor": 1,
+            "legendFormat": "Sent",
+            "metric": "network",
+            "refId": "B",
+            "step": 10
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Network I/O pressure",
+        "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 0,
+            "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "format": "Bps",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "format": "Bps",
+            "logBase": 1,
+            "show": false
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {
+            "max - istio-proxy": "#890f02",
+            "max - master": "#bf1b00",
+            "max - prometheus": "#bf1b00"
+        },
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+        },
+        "decimals": 2,
+        "editable": false,
+        "error": false,
+        "fill": 0,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 8,
+            "y": 10
+        },
+        "hiddenSeries": false,
+        "id": 77,
+        "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": false,
+            "sideWidth": 200,
+            "sort": "current",
+            "sortDesc": true,
+            "total": false,
+            "values": true
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "10.2.2",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "avg(nginx_ingress_controller_nginx_process_resident_memory_bytes{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}) ",
+            "format": "time_series",
+            "instant": false,
+            "interval": "10s",
+            "intervalFactor": 1,
+            "legendFormat": "nginx",
+            "metric": "container_memory_usage:sort_desc",
+            "refId": "A",
+            "step": 10
+            }
+        ],
+        "thresholds": [],
+        "timeRegions": [],
+        "title": "Average Memory Usage",
+        "tooltip": {
+            "msResolution": false,
+            "shared": true,
+            "sort": 2,
+            "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "format": "bytes",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "format": "short",
+            "logBase": 1,
+            "show": false
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "aliasColors": {
+            "max - istio-proxy": "#890f02",
+            "max - master": "#bf1b00"
+        },
+        "bars": false,
+        "dashLength": 10,
+        "dashes": false,
+        "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+        },
+        "decimals": 3,
+        "editable": false,
+        "error": false,
+        "fill": 0,
+        "fillGradient": 0,
+        "grid": {},
+        "gridPos": {
+            "h": 6,
+            "w": 8,
+            "x": 16,
+            "y": 10
+        },
+        "height": "",
+        "hiddenSeries": false,
+        "id": 79,
+        "legend": {
+            "alignAsTable": true,
+            "avg": true,
+            "current": true,
+            "max": false,
+            "min": false,
+            "rightSide": false,
+            "show": false,
+            "total": false,
+            "values": true
+        },
+        "lines": true,
+        "linewidth": 2,
+        "links": [],
+        "nullPointMode": "connected",
+        "options": {
+            "alertThreshold": true
+        },
+        "percentage": false,
+        "pluginVersion": "10.2.2",
+        "pointradius": 5,
+        "points": false,
+        "renderer": "flot",
+        "seriesOverrides": [],
+        "spaceLength": 10,
+        "stack": false,
+        "steppedLine": false,
+        "targets": [
+            {
+            "expr": "avg (rate (nginx_ingress_controller_nginx_process_cpu_seconds_total{controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\"}[2m])) ",
+            "format": "time_series",
+            "interval": "10s",
+            "intervalFactor": 1,
+            "legendFormat": "nginx",
+            "metric": "container_cpu",
+            "refId": "A",
+            "step": 10
+            }
+        ],
+        "thresholds": [
+            {
+            "colorMode": "critical",
+            "fill": true,
+            "line": true,
+            "op": "gt"
+            }
+        ],
+        "timeRegions": [],
+        "title": "Average CPU Usage",
+        "tooltip": {
+            "msResolution": true,
+            "shared": true,
+            "sort": 2,
+            "value_type": "cumulative"
+        },
+        "type": "graph",
+        "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+        },
+        "yaxes": [
+            {
+            "format": "none",
+            "label": "cores",
+            "logBase": 1,
+            "show": true
+            },
+            {
+            "format": "short",
+            "logBase": 1,
+            "show": true
+            }
+        ],
+        "yaxis": {
+            "align": false
+        }
+        },
+        {
+        "columns": [],
+        "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+        },
+        "description": "This data is real time, independent of dashboard time range",
+        "fontSize": "100%",
+        "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 16
+        },
+        "hideTimeOverride": false,
+        "id": 75,
+        "links": [],
+        "pageSize": 7,
+        "repeatDirection": "h",
+        "scroll": true,
+        "showHeader": true,
+        "sort": {
+            "col": 1,
+            "desc": true
+        },
+        "styles": [
+            {
+            "alias": "Ingress",
+            "align": "auto",
+            "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+            ],
+            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+            "decimals": 2,
+            "pattern": "ingress",
+            "preserveFormat": false,
+            "sanitize": false,
+            "thresholds": [],
+            "type": "string",
+            "unit": "short"
+            },
+            {
+            "alias": "Requests",
+            "align": "auto",
+            "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+            ],
+            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+            "decimals": 2,
+            "pattern": "Value #A",
+            "thresholds": [
+                ""
+            ],
+            "type": "number",
+            "unit": "ops"
+            },
+            {
+            "alias": "Errors",
+            "align": "auto",
+            "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+            ],
+            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+            "decimals": 2,
+            "pattern": "Value #B",
+            "thresholds": [],
+            "type": "number",
+            "unit": "ops"
+            },
+            {
+            "alias": "P50 Latency",
+            "align": "auto",
+            "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+            ],
+            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+            "decimals": 0,
+            "link": false,
+            "pattern": "Value #C",
+            "thresholds": [],
+            "type": "number",
+            "unit": "dtdurations"
+            },
+            {
+            "alias": "P90 Latency",
+            "align": "auto",
+            "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+            ],
+            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+            "decimals": 0,
+            "pattern": "Value #D",
+            "thresholds": [],
+            "type": "number",
+            "unit": "dtdurations"
+            },
+            {
+            "alias": "P99 Latency",
+            "align": "auto",
+            "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+            ],
+            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+            "decimals": 0,
+            "pattern": "Value #E",
+            "thresholds": [],
+            "type": "number",
+            "unit": "dtdurations"
+            },
+            {
+            "alias": "IN",
+            "align": "auto",
+            "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+            ],
+            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+            "decimals": 2,
+            "pattern": "Value #F",
+            "thresholds": [
+                ""
+            ],
+            "type": "number",
+            "unit": "Bps"
+            },
+            {
+            "alias": "",
+            "align": "auto",
+            "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+            ],
+            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+            "decimals": 2,
+            "pattern": "Time",
+            "thresholds": [],
+            "type": "hidden",
+            "unit": "short"
+            },
+            {
+            "alias": "OUT",
+            "align": "auto",
+            "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+            ],
+            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+            "decimals": 2,
+            "mappingType": 1,
+            "pattern": "Value #G",
+            "thresholds": [],
+            "type": "number",
+            "unit": "Bps"
+            }
+        ],
+        "targets": [
+            {
+            "expr": "histogram_quantile(0.50, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (le, ingress))",
+            "format": "table",
+            "hide": false,
+            "instant": true,
+            "intervalFactor": 1,
+            "legendFormat": {{- "{{ ingress }}" | quote -}},
+            "refId": "C"
+            },
+            {
+            "expr": "histogram_quantile(0.90, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (le, ingress))",
+            "format": "table",
+            "hide": false,
+            "instant": true,
+            "intervalFactor": 1,
+            "legendFormat": {{- "{{ ingress }}" | quote -}},
+            "refId": "D"
+            },
+            {
+            "expr": "histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (le, ingress))",
+            "format": "table",
+            "hide": false,
+            "instant": true,
+            "intervalFactor": 1,
+            "legendFormat": {{- "{{ destination_service }}" | quote -}},
+            "refId": "E"
+            },
+            {
+            "expr": "sum(irate(nginx_ingress_controller_request_size_sum{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (ingress)",
+            "format": "table",
+            "hide": false,
+            "instant": true,
+            "interval": "",
+            "intervalFactor": 1,
+            "legendFormat": {{- "{{ ingress }}" | quote -}},
+            "refId": "F"
+            },
+            {
+            "expr": "sum(irate(nginx_ingress_controller_response_size_sum{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (ingress)",
+            "format": "table",
+            "instant": true,
+            "intervalFactor": 1,
+            "legendFormat": {{- "{{ ingress }}" | quote -}},
+            "refId": "G"
+            }
+        ],
+        "title": "Ingress Percentile Response Times and Transfer Rates",
+        "transform": "table",
+        "type": "table-old"
+        },
+        {
+        "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+        },
+        "fieldConfig": {
+            "defaults": {
+            "color": {
+                "mode": "palette-classic"
+            },
+            "custom": {
+                "axisBorderShow": false,
+                "axisCenteredZero": false,
+                "axisColorMode": "text",
+                "axisLabel": "",
+                "axisPlacement": "auto",
+                "barAlignment": 0,
+                "drawStyle": "line",
+                "fillOpacity": 0,
+                "gradientMode": "none",
+                "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+                },
+                "insertNulls": false,
+                "lineInterpolation": "linear",
+                "lineWidth": 1,
+                "pointSize": 5,
+                "scaleDistribution": {
+                "type": "linear"
+                },
+                "showPoints": "auto",
+                "spanNulls": false,
+                "stacking": {
+                "group": "A",
+                "mode": "none"
+                },
+                "thresholdsStyle": {
+                "mode": "off"
+                }
+            },
+            "mappings": [],
+            "thresholds": {
+                "mode": "absolute",
+                "steps": [
+                {
+                    "color": "green"
+                },
+                {
+                    "color": "red",
+                    "value": 80
+                }
+                ]
+            },
+            "unit": "s"
+            },
+            "overrides": [
+            {
+                "__systemRef": "hideSeriesFrom",
+                "matcher": {
+                "id": "byNames",
+                "options": {
+                    "mode": "exclude",
+                    "names": [
+                    "P90-grafana"
+                    ],
+                    "prefix": "All except:",
+                    "readOnly": true
+                }
+                },
+                "properties": [
+                {
+                    "id": "custom.hideFrom",
+                    "value": {
+                    "legend": false,
+                    "tooltip": false,
+                    "viz": true
+                    }
+                }
+                ]
+            }
+            ]
+        },
+        "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 0,
+            "y": 24
+        },
+        "hideTimeOverride": false,
+        "id": 91,
+        "links": [],
+        "options": {
+            "legend": {
+            "calcs": [],
+            "displayMode": "list",
+            "placement": "bottom",
+            "showLegend": true
+            },
+            "tooltip": {
+            "mode": "multi",
+            "sort": "none"
+            }
+        },
+        "pluginVersion": "8.3.4",
+        "repeatDirection": "h",
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.80, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (ingress,le))",
+            "hide": false,
+            "legendFormat": {{- "P80-{{ingress}}" | quote -}},
+            "range": true,
+            "refId": "A"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.90, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (ingress,le))",
+            "hide": false,
+            "legendFormat": {{- "P90-{{ingress}}" | quote -}},
+            "range": true,
+            "refId": "B"
+            },
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "histogram_quantile(0.99, sum(rate(nginx_ingress_controller_request_duration_seconds_bucket{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (ingress,le))",
+            "hide": false,
+            "legendFormat": {{- "P99-{{ingress}}" | quote -}},
+            "range": true,
+            "refId": "C"
+            }
+        ],
+        "title": "Ingress Percentile Response Times",
+        "type": "timeseries"
+        },
+        {
+        "cards": {},
+        "color": {
+            "cardColor": "#b4ff00",
+            "colorScale": "sqrt",
+            "colorScheme": "interpolateWarm",
+            "exponent": 0.5,
+            "mode": "spectrum"
+        },
+        "dataFormat": "tsbuckets",
+        "datasource": {
+            "type": "prometheus",
+            "uid": "prometheus"
+        },
+        "description": "",
+        "fieldConfig": {
+            "defaults": {
+            "custom": {
+                "hideFrom": {
+                "legend": false,
+                "tooltip": false,
+                "viz": false
+                },
+                "scaleDistribution": {
+                "type": "linear"
+                }
+            }
+            },
+            "overrides": []
+        },
+        "gridPos": {
+            "h": 7,
+            "w": 12,
+            "x": 12,
+            "y": 24
+        },
+        "heatmap": {},
+        "hideZeroBuckets": false,
+        "highlightCards": true,
+        "id": 89,
+        "legend": {
+            "show": true
+        },
+        "options": {
+            "calculate": false,
+            "calculation": {},
+            "cellGap": 2,
+            "cellValues": {},
+            "color": {
+            "exponent": 0.5,
+            "fill": "#b4ff00",
+            "mode": "scheme",
+            "reverse": false,
+            "scale": "exponential",
+            "scheme": "Warm",
+            "steps": 128
+            },
+            "exemplars": {
+            "color": "rgba(255,0,255,0.7)"
+            },
+            "filterValues": {
+            "le": 1e-9
+            },
+            "legend": {
+            "show": true
+            },
+            "rowsFrame": {
+            "layout": "auto"
+            },
+            "showValue": "never",
+            "tooltip": {
+            "show": true,
+            "yHistogram": true
+            },
+            "yAxis": {
+            "axisPlacement": "left",
+            "reverse": false,
+            "unit": "s"
+            }
+        },
+        "pluginVersion": "10.2.2",
+        "reverseYBuckets": false,
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "sum(increase(nginx_ingress_controller_request_duration_seconds_bucket{ingress!=\"\",controller_pod=~\"$controller\",controller_class=~\"$controller_class\",controller_namespace=~\"$namespace\",ingress=~\"$ingress\"}[2m])) by (ingress)",
+            "hide": false,
+            "legendFormat": {{- "{{ingress}}" | quote -}},
+            "range": true,
+            "refId": "A"
+            }
+        ],
+        "title": "Ingress Request Latency Heatmap",
+        "tooltip": {
+            "show": true,
+            "showHistogram": true
+        },
+        "type": "heatmap",
+        "xAxis": {
+            "show": true
+        },
+        "yAxis": {
+            "format": "s",
+            "logBase": 1,
+            "show": true
+        },
+        "yBucketBound": "auto"
+        },
+        {
+        "columns": [
+            {
+            "$$hashKey": "object:1068",
+            "text": "Current",
+            "value": "current"
+            }
+        ],
+        "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+        },
+        "fontSize": "100%",
+        "gridPos": {
+            "h": 8,
+            "w": 24,
+            "x": 0,
+            "y": 31
+        },
+        "height": "1024",
+        "id": 85,
+        "links": [],
+        "pageSize": 7,
+        "scroll": true,
+        "showHeader": true,
+        "sort": {
+            "col": 1,
+            "desc": false
+        },
+        "styles": [
+            {
+            "alias": "Time",
+            "align": "auto",
+            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+            "pattern": "Time",
+            "type": "date"
+            },
+            {
+            "alias": "TTL",
+            "align": "auto",
+            "colorMode": "cell",
+            "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+            ],
+            "dateFormat": "YYYY-MM-DD HH:mm:ss",
+            "decimals": 0,
+            "pattern": "Current",
+            "thresholds": [
+                "0",
+                "691200"
+            ],
+            "type": "number",
+            "unit": "s"
+            },
+            {
+            "alias": "",
+            "align": "auto",
+            "colors": [
+                "rgba(245, 54, 54, 0.9)",
+                "rgba(237, 129, 40, 0.89)",
+                "rgba(50, 172, 45, 0.97)"
+            ],
+            "decimals": 2,
+            "pattern": "/.*/",
+            "thresholds": [],
+            "type": "number",
+            "unit": "short"
+            }
+        ],
+        "targets": [
+            {
+            "datasource": {
+                "type": "prometheus",
+                "uid": "prometheus"
+            },
+            "editorMode": "code",
+            "expr": "avg (nginx_ingress_controller_ssl_expire_time_seconds{pod=~\"$controller\",namespace=~\"$namespace\", host=~\"$host\"}) by (host) - time()",
+            "format": "time_series",
+            "intervalFactor": 1,
+            "legendFormat": {{- "{{ host }}" | quote -}},
+            "metric": "gke_letsencrypt_cert_expiration",
+            "range": true,
+            "refId": "A",
+            "step": 1
+            }
+        ],
+        "title": "Ingress Certificate Expiry",
+        "transform": "timeseries_aggregations",
+        "type": "table-old"
+        }
+    ],
+    "refresh": "30s",
+    "schemaVersion": 38,
+    "tags": [
+        "nginx"
+    ],
+    "templating": {
+        "list": [
+        {
+            "current": {
+            "selected": false,
+            "text": "Prometheus",
+            "value": "prometheus"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "datasource",
+            "multi": false,
+            "name": "DS_PROMETHEUS",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+        },
+        {
+            "allValue": ".*",
+            "current": {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+            },
+            "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+            },
+            "definition": "",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Namespace",
+            "multi": false,
+            "name": "namespace",
+            "options": [],
+            "query": {
+            "query": "label_values(nginx_ingress_controller_config_hash, controller_namespace)",
+            "refId": "Prometheus-namespace-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "allValue": ".*",
+            "current": {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+            },
+            "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+            },
+            "definition": "",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Controller Class",
+            "multi": false,
+            "name": "controller_class",
+            "options": [],
+            "query": {
+            "query": "label_values(nginx_ingress_controller_config_hash{namespace=~\"$namespace\"}, controller_class) ",
+            "refId": "Prometheus-controller_class-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "allValue": ".*",
+            "current": {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+            },
+            "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+            },
+            "definition": "",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Controller",
+            "multi": false,
+            "name": "controller",
+            "options": [],
+            "query": {
+            "query": "label_values(nginx_ingress_controller_config_hash{namespace=~\"$namespace\",controller_class=~\"$controller_class\"}, controller_pod) ",
+            "refId": "Prometheus-controller-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 0,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "allValue": ".*",
+            "current": {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+            },
+            "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+            },
+            "definition": "",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Ingress",
+            "multi": false,
+            "name": "ingress",
+            "options": [],
+            "query": {
+            "query": "label_values(nginx_ingress_controller_requests{namespace=~\"$namespace\",controller_class=~\"$controller_class\",controller_pod=~\"$controller\"}, ingress) ",
+            "refId": "Prometheus-ingress-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 2,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+        },
+        {
+            "allValue": ".*",
+            "current": {
+            "selected": false,
+            "text": "All",
+            "value": "$__all"
+            },
+            "datasource": {
+            "type": "prometheus",
+            "uid": "${DS_PROMETHEUS}"
+            },
+            "definition": "label_values(nginx_ingress_controller_requests{controller_class=~\"$controller_class\", namespace=~\"$namespace\", controller_pod=~\"$controller\"},host)",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Host",
+            "multi": false,
+            "name": "host",
+            "options": [],
+            "query": {
+            "qryType": 1,
+            "query": "label_values(nginx_ingress_controller_requests{controller_class=~\"$controller_class\", namespace=~\"$namespace\", controller_pod=~\"$controller\"},host)",
+            "refId": "PrometheusVariableQueryEditor-VariableQuery"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 2,
+            "type": "query"
+        }
+        ]
+    },
+    "time": {
+        "from": "now-1h",
+        "to": "now"
+    },
+    "timepicker": {
+        "refresh_intervals": [
+        "30s",
+        "2m",
+        "5m",
+        "15m",
+        "30m",
+        "1h",
+        "2h",
+        "1d"
+        ],
+        "time_options": [
+        "5m",
+        "15m",
+        "1h",
+        "6h",
+        "12h",
+        "24h",
+        "2d",
+        "7d",
+        "30d"
+        ]
+    },
+    "timezone": "browser",
+    "title": "NGINX Ingress controller",
+    "uid": "nginx",
+    "version": 12,
+    "weekStart": ""
+    }
+{{- end }}

--- a/charts/grafana-dashboards/templates/ingress-nginx/controller.yaml
+++ b/charts/grafana-dashboards/templates/ingress-nginx/controller.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Values.ingressNginx.namespace }}
   labels:
     grafana_dashboard: "1"
+  annotations:
+    k8s-sidecar-target-directory: {{ .Values.ingressNginx.targetDirectory }}
 data:
   ingress-nginx-controller.json: |
     {

--- a/charts/grafana-dashboards/templates/ingress-nginx/request-handling-performance.yaml
+++ b/charts/grafana-dashboards/templates/ingress-nginx/request-handling-performance.yaml
@@ -1,0 +1,1012 @@
+{{- if and .Values.ingressNginx.enabled .Values.ingressNginx.requestHandlingPerformance -}}
+kind: ConfigMap
+apiVersion: v1
+metadata:
+  name: ingress-nginx-request-handling-performance
+  namespace: {{ .Values.ingressNginx.namespace }}
+  labels:
+    grafana_dashboard: "1"
+data:
+  ingress-nginx-request-handling-performance.json: |
+    {
+      "annotations": {
+        "list": [
+          {
+            "builtIn": 1,
+            "datasource": {
+              "type": "datasource",
+              "uid": "grafana"
+            },
+            "enable": true,
+            "hide": true,
+            "iconColor": "rgba(0, 211, 255, 1)",
+            "name": "Annotations & Alerts",
+            "target": {
+              "limit": 100,
+              "matchAny": false,
+              "tags": [],
+              "type": "dashboard"
+            },
+            "type": "dashboard"
+          }
+        ]
+      },
+      "description": "",
+      "editable": true,
+      "fiscalYearStartMonth": 0,
+      "gnetId": 9614,
+      "graphTooltip": 1,
+      "id": 9,
+      "links": [],
+      "liveNow": false,
+      "panels": [
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Total time for NGINX and upstream servers to process a request and send a response",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 0
+          },
+          "hiddenSeries": false,
+          "id": 91,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "histogram_quantile(\n  0.5,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_request_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
+              "interval": "",
+              "legendFormat": ".5",
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "histogram_quantile(\n  0.95,\n  sum by (le)(\n    rate(\n    nginx_ingress_controller_request_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
+              "interval": "",
+              "legendFormat": ".95",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "histogram_quantile(\n  0.99,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_request_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
+              "interval": "",
+              "legendFormat": ".99",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Request Latency Percentiles",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "The time spent on receiving the response from the upstream server",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 0
+          },
+          "hiddenSeries": false,
+          "id": 94,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "histogram_quantile(\n  0.5,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_response_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": ".5",
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "histogram_quantile(\n  0.95,\n  sum by (le)(\n    rate(\n    nginx_ingress_controller_response_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
+              "interval": "",
+              "legendFormat": ".95",
+              "refId": "B"
+            },
+            {
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "histogram_quantile(\n  0.99,\n  sum by (le)(\n    rate(\n      nginx_ingress_controller_response_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
+              "interval": "",
+              "legendFormat": ".99",
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Upstream Response Latency Percentiles",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 93,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "  sum by (method, host, path)(\n    rate(\n      nginx_ingress_controller_request_duration_seconds_count{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": {{- "{{ method }} {{ host }} {{path }}" | quote -}},
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Request Rate by Method and Path",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "reqps",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "For each path observed, its median upstream response time",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 8
+          },
+          "hiddenSeries": false,
+          "id": 98,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "histogram_quantile(\n  .5,\n  sum by (le, method, host, path)(\n    rate(\n      nginx_ingress_controller_response_duration_seconds_bucket{\n        ingress =~ \"$ingress\"\n      }[5m]\n    )\n  )\n)",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": {{- "{{ method }} {{ host }} {{path }}" | quote -}},
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Median Upstream Response Time by Method and Path",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "Percentage of 4xx and 5xx responses among all responses.",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 16
+          },
+          "hiddenSeries": false,
+          "id": 100,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null as zero",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "sum by (method, host, path) (rate(nginx_ingress_controller_request_duration_seconds_count{\n  ingress =~ \"$ingress\",\n  status =~ \"[4-5].*\"\n}[5m])) / sum by (method, host, path) (rate(nginx_ingress_controller_request_duration_seconds_count{\n  ingress =~ \"$ingress\",\n}[5m]))",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": {{- "{{ method }} {{ host }} {{path }}" | quote -}},
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Response Error Rate by Method and Path",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "percentunit",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "description": "For each path observed, the sum of upstream request time",
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 16
+          },
+          "hiddenSeries": false,
+          "id": 102,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "10.2.2",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "sum by (method, host, path) (rate(nginx_ingress_controller_response_duration_seconds_sum{ingress =~ \"$ingress\"}[5m]))",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": {{- "{{ method }} {{ host }} {{path }}" | quote -}},
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Upstream Response Time by Method and Path",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 24
+          },
+          "hiddenSeries": false,
+          "id": 101,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "  sum (\n    rate(\n      nginx_ingress_controller_request_duration_seconds_count{\n        ingress =~ \"$ingress\",\n        status =~\"[4-5].*\",\n      }[5m]\n    )\n  ) by(method, host, path, status)\n",
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": {{- "{{ method }} {{ host }} {{path }} {{ status }}" | quote -}},
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Response Error Rate by Method and Path",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "reqps",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 12,
+            "y": 24
+          },
+          "hiddenSeries": false,
+          "id": 99,
+          "legend": {
+            "alignAsTable": true,
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "rightSide": true,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "sum (\n  rate (\n      nginx_ingress_controller_response_size_sum {\n        ingress =~ \"$ingress\",\n      }[5m]\n  )\n)  by (method, host, path) / sum (\n  rate(\n      nginx_ingress_controller_response_size_count {\n        ingress =~ \"$ingress\",\n      }[5m]\n  )\n) by (method, host, path)\n",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": {{- "{{ method }} {{ host }} {{path }}" | quote -}},
+              "refId": "D"
+            },
+            {
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "    sum (rate(nginx_ingress_controller_response_size_bucket{\n        ingress =~ \"$ingress\",\n    }[5m])) by (le)\n",
+              "hide": true,
+              "legendFormat": {{- "{{le}}" | quote -}},
+              "refId": "A"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Average Response Size by Method and Path",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "decbytes",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        },
+        {
+          "aliasColors": {},
+          "bars": false,
+          "dashLength": 10,
+          "dashes": false,
+          "datasource": {
+            "uid": "${DS_PROMETHEUS}"
+          },
+          "fieldConfig": {
+            "defaults": {
+              "links": []
+            },
+            "overrides": []
+          },
+          "fill": 1,
+          "fillGradient": 0,
+          "gridPos": {
+            "h": 8,
+            "w": 12,
+            "x": 0,
+            "y": 32
+          },
+          "hiddenSeries": false,
+          "id": 96,
+          "legend": {
+            "avg": false,
+            "current": false,
+            "max": false,
+            "min": false,
+            "show": true,
+            "total": false,
+            "values": false
+          },
+          "lines": true,
+          "linewidth": 1,
+          "nullPointMode": "null",
+          "options": {
+            "alertThreshold": true
+          },
+          "percentage": false,
+          "pluginVersion": "8.3.4",
+          "pointradius": 2,
+          "points": false,
+          "renderer": "flot",
+          "seriesOverrides": [],
+          "spaceLength": 10,
+          "stack": false,
+          "steppedLine": false,
+          "targets": [
+            {
+              "datasource": {
+                "uid": "${DS_PROMETHEUS}"
+              },
+              "expr": "sum (\n  rate(\n      nginx_ingress_controller_ingress_upstream_latency_seconds_sum {\n        ingress =~ \"$ingress\",\n      }[5m]\n)) / sum (\n  rate(\n      nginx_ingress_controller_ingress_upstream_latency_seconds_count {\n        ingress =~ \"$ingress\",\n      }[5m]\n  )\n)\n",
+              "hide": false,
+              "instant": false,
+              "interval": "",
+              "intervalFactor": 1,
+              "legendFormat": "average",
+              "refId": "B"
+            }
+          ],
+          "thresholds": [],
+          "timeRegions": [],
+          "title": "Upstream Service Latency",
+          "tooltip": {
+            "shared": true,
+            "sort": 2,
+            "value_type": "individual"
+          },
+          "type": "graph",
+          "xaxis": {
+            "mode": "time",
+            "show": true,
+            "values": []
+          },
+          "yaxes": [
+            {
+              "format": "s",
+              "logBase": 1,
+              "show": true
+            },
+            {
+              "format": "short",
+              "logBase": 1,
+              "show": true
+            }
+          ],
+          "yaxis": {
+            "align": false
+          }
+        }
+      ],
+      "refresh": "30s",
+      "schemaVersion": 38,
+      "tags": [
+        "nginx"
+      ],
+      "templating": {
+        "list": [
+          {
+            "current": {
+              "selected": false,
+              "text": "Prometheus",
+              "value": "prometheus"
+            },
+            "hide": 0,
+            "includeAll": false,
+            "label": "datasource",
+            "multi": false,
+            "name": "DS_PROMETHEUS",
+            "options": [],
+            "query": "prometheus",
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "type": "datasource"
+          },
+          {
+            "allValue": ".*",
+            "current": {
+              "selected": false,
+              "text": "All",
+              "value": "$__all"
+            },
+            "datasource": {
+              "uid": "${DS_PROMETHEUS}"
+            },
+            "definition": "label_values(nginx_ingress_controller_requests, ingress) ",
+            "hide": 0,
+            "includeAll": true,
+            "label": "Service Ingress",
+            "multi": false,
+            "name": "ingress",
+            "options": [],
+            "query": {
+              "query": "label_values(nginx_ingress_controller_requests, ingress) ",
+              "refId": "Prometheus-ingress-Variable-Query"
+            },
+            "refresh": 1,
+            "regex": "",
+            "skipUrlSync": false,
+            "sort": 2,
+            "tagValuesQuery": "",
+            "tagsQuery": "",
+            "type": "query",
+            "useTags": false
+          }
+        ]
+      },
+      "time": {
+        "from": "now-15m",
+        "to": "now"
+      },
+      "timepicker": {
+        "refresh_intervals": [
+          "5s",
+          "10s",
+          "30s",
+          "2m",
+          "5m",
+          "15m",
+          "30m",
+          "1h",
+          "2h",
+          "1d"
+        ],
+        "time_options": [
+          "5m",
+          "15m",
+          "1h",
+          "6h",
+          "12h",
+          "24h",
+          "2d",
+          "7d",
+          "30d"
+        ]
+      },
+      "timezone": "browser",
+      "title": "Request Handling Performance",
+      "uid": "4GFbkOsZk",
+      "version": 1,
+      "weekStart": ""
+    }
+{{- end }}

--- a/charts/grafana-dashboards/templates/ingress-nginx/request-handling-performance.yaml
+++ b/charts/grafana-dashboards/templates/ingress-nginx/request-handling-performance.yaml
@@ -6,6 +6,8 @@ metadata:
   namespace: {{ .Values.ingressNginx.namespace }}
   labels:
     grafana_dashboard: "1"
+  annotations:
+    k8s-sidecar-target-directory: {{ .Values.ingressNginx.targetDirectory }}
 data:
   ingress-nginx-request-handling-performance.json: |
     {

--- a/charts/grafana-dashboards/values.yaml
+++ b/charts/grafana-dashboards/values.yaml
@@ -1,0 +1,13 @@
+# Default values for grafana-dashboards.
+# This is a YAML-formatted file.
+# Declare variables to be passed into your templates.
+
+ingressNginx:
+  enabled: true
+  namespace: grafana
+  # -- provision `NGINX Ingress controller` dashboard
+  controller: true
+  # -- provision `NGINX Ingress controller - Loki` dashboard
+  controllerLoki: true
+  # -- provision `Request Handling Performance` dashboard
+  requestHandlingPerformance: true

--- a/charts/grafana-dashboards/values.yaml
+++ b/charts/grafana-dashboards/values.yaml
@@ -2,9 +2,26 @@
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
 
+# you should define target directories for dashboards in configuration kube-prometheus-stack
+# grafana:
+#   dashboardProviders:
+#     dashboardproviders.yaml:
+#       apiVersion: 1
+#       providers:
+#         - name: 'ingress-nginx'
+#           orgId: 1
+#           type: file
+#           folder: 'ingress-nginx'
+#           disableDeletion: true
+#           editable: false
+#           allowUiUpdates: false
+#           options:
+#             path: /var/lib/grafana/dashboards/ingress-nginx/
+
 ingressNginx:
   enabled: true
   namespace: grafana
+  targetDirectory: /var/lib/grafana/dashboards/ingress-nginx/
   # -- provision `NGINX Ingress controller` dashboard
   controller: true
   # -- provision `NGINX Ingress controller - Loki` dashboard


### PR DESCRIPTION
### Summary

JIRA: <https://saritasa.atlassian.net/browse/USAWS-23>

Added `grafana-dashboards` helm chart (only dashboard for ingress-nginx).

[ingress-nginx dashboards](https://grafana.teleport.usummitapp.net/dashboards/f/b2e50ac0-8808-42da-a530-cd0563f1dc76/)

Related PR: <https://github.com/saritasa-nest/usummit-kubernetes-aws/pull/9> 