### PR TITLE
feat: fix typo in tekton-apps roles creation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2024-01-31
+
+[prod]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/112)
+- Fix typo in `tekton-apps` helm chart for `build-pipeline-role` Role generation
+
 ## 2024-01-25
 
 [prod]

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: "v0.29.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.18
+version: 0.2.19-dev.1
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: "v0.29.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.19-dev.1
+version: 0.2.19
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 0.2.18](https://img.shields.io/badge/Version-0.2.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
+![Version: 0.2.19-dev.1](https://img.shields.io/badge/Version-0.2.19--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 0.2.19-dev.1](https://img.shields.io/badge/Version-0.2.19--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
+![Version: 0.2.19](https://img.shields.io/badge/Version-0.2.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-apps/templates/roles.yaml
+++ b/charts/tekton-apps/templates/roles.yaml
@@ -15,7 +15,7 @@ kind: Role
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
  name: {{ include "tekton-apps.resourceName" (set $data "suffix" "build-pipeline-role") }}
- namespace: {{ include "tekton-apps.set-namespace-from-component-or-project" (dict "component" $component "project" $project "component_name" "component") }}
+ namespace: {{ or ((.component).argocd).destinationNamespace $.Release.Namespace }}
 rules:
   - apiGroups:  ["extensions", "apps", "batch", ""]
     resources:  ["services", "deployments", "pods", "jobs", "pods/log"]


### PR DESCRIPTION
### Summary

Task: [SD-373](https://saritasa.atlassian.net/browse/SD-373)


Suddenly our Tekton stopped sending Slack notifications for all projects with this error, so I found bug that appeared from this PR - https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/98/files (we should have `build-pipeline-role` roles in `ci` namespace by default).

![image](https://github.com/saritasa-nest/saritasa-devops-helm-charts/assets/26448672/b0bcb1e1-b9e4-4ce7-a0a4-40ef600fbab9)

Original Error: 
```
Error from server (Forbidden): [pipelineruns.tekton.dev](http://pipelineruns.tekton.dev/) "ats-dart-backend-dev-kaniko-build-pipeline-run-vv6cp" is forbidden: User "system:serviceaccount:ci:ats-dart-backend-dev-build-pipeline-sa" cannot get resource "pipelineruns" in API group "[tekton.dev](http://tekton.dev/)" in the namespace "ci": RBAC: [role.rbac.authorization.k8s.io](http://role.rbac.authorization.k8s.io/) "ats-dart-backend-dev-build-pipeline-role" not found
```

![image](https://github.com/saritasa-nest/saritasa-devops-helm-charts/assets/26448672/87a2ec1c-8b01-4338-9bae-77686854cd22)


[SD-373]: https://saritasa.atlassian.net/browse/SD-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

Now there are no such issues
![image](https://github.com/saritasa-nest/saritasa-devops-helm-charts/assets/26448672/a8d1fb2f-51a9-4f0f-9632-83ede3c1d8a1)
