### PR TITLE
feat: edit updateStrategy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2024-09-02
+
+[prod]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/131)
+- Changed strategy type in wordpress helm chart to `Recreate`
+
 ## 2024-08-28
 
 [prod]

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: "v0.29.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.20
+version: 0.2.21
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-apps/templates/wordpress/argocd_applications.yaml
+++ b/charts/tekton-apps/templates/wordpress/argocd_applications.yaml
@@ -69,10 +69,7 @@ spec:
         {{- if .updateStrategy }}
           {{- toYaml .updateStrategy | nindent 10 }}
         {{- else }}
-          type: RollingUpdate
-          rollingUpdate:
-            maxSurge: 0%
-            maxUnavailable: 100%
+          type: Recreate
         {{- end }}
 
         replicaCount: {{ .replicaCount | default 1}}


### PR DESCRIPTION
### Summary

Task: [SD-1004](https://saritasa.atlassian.net/browse/SD-1004)

- Changed strategy type to `Recreate`

With the `RollingUpdate` strategy type we get an error:
```
Multi-Attach error for volume "pvc-007567f3-a6fd-498e-9fc7-f2cbf4d46631" Volume is already used by pod(s) emapp-wordpress-dev-56dfdd6d97-2dbt7
```

[SD-1004]: https://saritasa.atlassian.net/browse/SD-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ