### PR TITLE
feat: update path for readinessProbe and customLivenessProbe

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2024-09-09
+
+[prod]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/132)
+- update path for `readinessProbe` and `customLivenessProbe`
+
 ## 2024-09-02
 
 [prod]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 [prod]
 
 - [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/132)
-- update path for `readinessProbe` and `customLivenessProbe`
+- update path for `readinessProbe` and `customLivenessProbe` in the wordpress helm chart
 
 ## 2024-09-02
 

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: "v0.29.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.2.21
+version: 0.2.22
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-apps/templates/wordpress/argocd_applications.yaml
+++ b/charts/tekton-apps/templates/wordpress/argocd_applications.yaml
@@ -185,7 +185,7 @@ spec:
 
         customLivenessProbe:
           httpGet:
-            path: /wp-login.php
+            path: /wp-admin/install.php
             port: 8080
             scheme: HTTP
           periodSeconds: 120
@@ -193,7 +193,7 @@ spec:
         readinessProbe:
           enabled: true
           httpGet:
-            path: /wp-login.php
+            path: /wp-admin/install.php
             port: 8080
             scheme: HTTP
           periodSeconds: 120

--- a/charts/tekton-apps/templates/wordpress/argocd_applications.yaml
+++ b/charts/tekton-apps/templates/wordpress/argocd_applications.yaml
@@ -185,7 +185,7 @@ spec:
 
         customLivenessProbe:
           httpGet:
-            path: /wp-admin/install.php
+            path: /wp-includes/js/jquery/jquery.min.js
             port: 8080
             scheme: HTTP
           periodSeconds: 120
@@ -193,7 +193,7 @@ spec:
         readinessProbe:
           enabled: true
           httpGet:
-            path: /wp-admin/install.php
+            path: /wp-includes/js/jquery/jquery.min.js
             port: 8080
             scheme: HTTP
           periodSeconds: 120


### PR DESCRIPTION
### Summary

Task: [SD-1004](https://saritasa.atlassian.net/browse/SD-1004)

- update path for `readinessProbe` and `customLivenessProbe`

Even though the page  [wp-login.php](https://saritasa-ci-experiments-wordpress.saritasa.rocks/wp-login.php) is in pod, we can't use it for  `readinessProbe` and `customLivenessProbe` because it must be in the `wp-content` folder in all `wordpress` repositories.

[SD-1004]: https://saritasa.atlassian.net/browse/SD-1004?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ