### PR TITLE
feat: release terraform-pod 1.11.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2025-04-11
+
+[prod]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/151)
+- Release new `terraform-pod` version with `1.11.3` terraform (it uses updated base image)
+
 ## 2025-03-13
 
 [prod]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@
 [prod]
 
 - [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/151)
-- Release new `terraform-pod` version with `1.11.3` terraform (it uses updated base image)
+- Release new `terraform-pod` version with `terraform:1.11.3` (based on `python:3.12.10-alpine3.21`)
 
 ## 2025-03-13
 

--- a/charts/terraform-pod/Chart.yaml
+++ b/charts/terraform-pod/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.0.35
+version: 0.0.36
 
 maintainers:
   - url: https://www.saritasa.com/
@@ -16,7 +16,7 @@ maintainers:
 # incremented each time you make changes to the application. Versions are not expected to
 # follow Semantic Versioning. They should reflect the version the application is using.
 # It is recommended to use it with quotes.
-appVersion: "1.11.2"
+appVersion: "1.11.3"
 
 description: |
   A Helm chart for running infra-dev-aws solutions
@@ -37,7 +37,7 @@ description: |
   helm upgrade --install CLIENT saritasa/terraform-pod \
     --namespace terraform \
     --set terraform.client=CLIENT \
-    --set image.tag=1.11.2 \
+    --set image.tag=1.11.3 \
     --set github.repository=saritasa-nest/CLIENT-infra-dev-aws \
     --set github.branch=feature/branch \
     --set github.username=YOUR-GITHUB-USERNAME \
@@ -55,7 +55,7 @@ description: |
     helm upgrade --install CLIENT saritasa/terraform-pod \
       --namespace terraform \
       --set terraform.client=CLIENT \
-      --set image.tag=1.11.2 \
+      --set image.tag=1.11.3 \
       --set github.repository=saritasa-nest/CLIENT-infra-aws \
       --set github.branch=feature/branch \
       --set github.username=YOUR-GITHUB-USERNAME \
@@ -90,7 +90,7 @@ description: |
   helm template --release-name debug-tfpod \
       --namespace terraform \
       --set terraform.client=saritasa \
-      --set image.tag=1.11.2 \
+      --set image.tag=1.11.3 \
       --set github.repository=saritasa-nest/some-repo-infra-aws \
       --set github.branch=feature/branch-name \
       --set github.username=your-username \

--- a/charts/terraform-pod/README.md
+++ b/charts/terraform-pod/README.md
@@ -31,7 +31,7 @@ terraform-pod
 
 ## `chart.version`
 
-![Version: 0.0.35](https://img.shields.io/badge/Version-0.0.35-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.2](https://img.shields.io/badge/AppVersion-1.11.2-informational?style=flat-square)
+![Version: 0.0.36](https://img.shields.io/badge/Version-0.0.36-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.11.3](https://img.shields.io/badge/AppVersion-1.11.3-informational?style=flat-square)
 
 ## Maintainers
 
@@ -59,7 +59,7 @@ helm repo add saritasa https://saritasa-nest.github.io/saritasa-devops-helm-char
 helm upgrade --install CLIENT saritasa/terraform-pod \
   --namespace terraform \
   --set terraform.client=CLIENT \
-  --set image.tag=1.11.2 \
+  --set image.tag=1.11.3 \
   --set github.repository=saritasa-nest/CLIENT-infra-dev-aws \
   --set github.branch=feature/branch \
   --set github.username=YOUR-GITHUB-USERNAME \
@@ -77,7 +77,7 @@ For infra-aws repos you may want to pass short-term TTL AWS credentials from the
   helm upgrade --install CLIENT saritasa/terraform-pod \
     --namespace terraform \
     --set terraform.client=CLIENT \
-    --set image.tag=1.11.2 \
+    --set image.tag=1.11.3 \
     --set github.repository=saritasa-nest/CLIENT-infra-aws \
     --set github.branch=feature/branch \
     --set github.username=YOUR-GITHUB-USERNAME \
@@ -112,7 +112,7 @@ unset AWS_VAULT && creds=$(aws-vault exec saritasa/v2/administrators --json) && 
 helm template --release-name debug-tfpod \
     --namespace terraform \
     --set terraform.client=saritasa \
-    --set image.tag=1.11.2 \
+    --set image.tag=1.11.3 \
     --set github.repository=saritasa-nest/some-repo-infra-aws \
     --set github.branch=feature/branch-name \
     --set github.username=your-username \
@@ -166,7 +166,7 @@ unset creds
 | github.username | string | `""` | github username (who runs this terraform code) |
 | image.pullPolicy | string | `"Always"` | pull policy |
 | image.repository | string | `"public.ecr.aws/saritasa/terraform"` | default docker registry |
-| image.tag | string | `"1.11.2"` | Overrides the image tag whose default is the chart appVersion. |
+| image.tag | string | `"1.11.3"` | Overrides the image tag whose default is the chart appVersion. |
 | imagePullSecrets | list | `[]` | docker pull secret |
 | infracost.apiKey | string | `""` | infracost api token value (optional, if passed - takes precedence over apiKeySecret) |
 | infracost.apiKeySecret | string | `"infracost-api-key"` | infracost api key secret (should contain a single attr: token=) |

--- a/charts/terraform-pod/values.yaml
+++ b/charts/terraform-pod/values.yaml
@@ -8,7 +8,7 @@ image:
   # -- pull policy
   pullPolicy: Always
   # -- Overrides the image tag whose default is the chart appVersion.
-  tag: "1.11.2"
+  tag: "1.11.3"
 
 github:
   # -- github app auth pem file used for terraform github provider authentication


### PR DESCRIPTION
### Summary

JIRA: [SD-373](https://saritasa.atlassian.net/browse/SD-373)

Changes:
* release a Helm chart for terraform-pod with terraform version 1.11.3 (uses [new `base` image](https://github.com/saritasa-nest/saritasa-devops-docker-images/pull/101))

[SD-373]: https://saritasa.atlassian.net/browse/SD-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ