### PR TITLE
feat: release tekton pipelines 2.0 SD-1271

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@
 
 [prod]
 
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/155)
+- Update tekton-pipelines:
+  - Removed resources blocks as they are deprecated
+  - Add new git-clone task from tekton catalog
+  - update all pipelines to use new versions and tasks
+
 - [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/154)
 - Update tekton:
   - Pipelines:    "1.1.0"

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: "v0.29.0"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0-dev.1
+version: 2.0.0
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 2.0.0-dev.1](https://img.shields.io/badge/Version-2.0.0--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 1.1.2](https://img.shields.io/badge/Version-1.1.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
+![Version: 2.0.0-dev.1](https://img.shields.io/badge/Version-2.0.0--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.0](https://img.shields.io/badge/AppVersion-v0.29.0-informational?style=flat-square)
 
 ## Maintainers
 
@@ -1604,10 +1604,9 @@ whitelistIP: |
 | defaultRegistry | string | `""` | default docker registry ex: XXX.dkr.ecr.us-west-2.amazonaws.com |
 | environment | string | `""` | environment these apps are handling possible values: dev, staging, prod |
 | gitBranchPrefixes[0] | string | `"develop"` |  |
-| nodeSelector | object | `{}` | node selector for event listener pod |
 | runPostInstallMountPvcJob | bool | `false` | run job that will mount created (but not bound) PVCs in order for argocd to mark the app as "healthy" |
 | serviceAccount.name | string | `"build-bot-sa"` |  |
-| serviceAccount.namespace | string | `""` |  |
+| serviceAccount.namespace | string | `"ci"` |  |
 | slack.imagesLocation | string | `"https://saritasa-rocks-ci.s3.us-west-2.amazonaws.com"` | slack notification images (s3 bucket prefix) |
 | slack.prefix | string | `"client"` | channel prefix |
 | slack.suffix | string | `"ci"` | channel suffix |

--- a/charts/tekton-pipelines/Chart.lock
+++ b/charts/tekton-pipelines/Chart.lock
@@ -1,6 +1,0 @@
-dependencies:
-- name: saritasa-tekton
-  repository: https://saritasa-nest.github.io/saritasa-devops-helm-charts/
-  version: 0.1.3
-digest: sha256:ff889e3128d47ae8237dfd00aa63373da1b688a88fd24adae3e519af096547e3
-generated: "2021-10-31T09:24:46.01257925-07:00"

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0-dev.51
+version: 2.0.0-dev.52
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0-dev.52
+version: 2.0.0-dev.53
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0-dev.54
+version: 2.0.0
 
 maintainers:
   - url: https://www.saritasa.com/
@@ -15,7 +15,7 @@ maintainers:
 dependencies:
   - name: saritasa-tekton
     repository: https://saritasa-nest.github.io/saritasa-devops-helm-charts/
-    version: ~0.1.x # TODO: update once tekton chart is released
+    version: ~2.0.x
     condition: saritasa-tekton.enabled
 
 description: |

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0-dev.53
+version: 2.0.0-dev.54
 
 maintainers:
   - url: https://www.saritasa.com/
@@ -15,7 +15,7 @@ maintainers:
 dependencies:
   - name: saritasa-tekton
     repository: https://saritasa-nest.github.io/saritasa-devops-helm-charts/
-    version: ~0.1.x #TODO: update once tekton chart is released
+    version: ~0.1.x # TODO: update once tekton chart is released
     condition: saritasa-tekton.enabled
 
 description: |

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 0.1.49
+version: 2.0.0-dev.49
 
 maintainers:
   - url: https://www.saritasa.com/
@@ -15,7 +15,7 @@ maintainers:
 dependencies:
   - name: saritasa-tekton
     repository: https://saritasa-nest.github.io/saritasa-devops-helm-charts/
-    version: ~0.1.x
+    version: ~0.1.x #TODO: update once tekton chart is released
     condition: saritasa-tekton.enabled
 
 description: |
@@ -98,7 +98,7 @@ description: |
           - name: build-hello-world
             image: node:22
             imagePullPolicy: IfNotPresent
-            workingDir: $(resources.inputs.app.path)
+            workingDir: $(workspaces.source.path)
             script: |
               #!/bin/bash
               echo "hello world"
@@ -106,7 +106,7 @@ description: |
           - name: pre-deploy-hello-world
             image: node:22
             imagePullPolicy: IfNotPresent
-            workingDir: $(resources.inputs.app.path)
+            workingDir: $(workspaces.source.path)
             script: |
               #!/bin/bash
               echo "hello world"
@@ -114,7 +114,7 @@ description: |
           - name: post-deploy-hello-world
             image: node:22
             imagePullPolicy: IfNotPresent
-            workingDir: $(resources.inputs.app.path)
+            workingDir: $(workspaces.source.path)
             script: |
               #!/bin/bash
               echo "hello world"
@@ -136,7 +136,7 @@ description: |
           name: build
           image: node:22
           imagePullPolicy: IfNotPresent
-          workingDir: $(resources.inputs.app.path)
+          workingDir: $(workspaces.source.path)
           script: |
             #!/bin/bash
             az login --identity --username <managed-indentity>
@@ -153,15 +153,15 @@ description: |
               -gid=$(params.group_id) \
               -process-type=$(params.process_type) \
               -skip-restore=$(params.skip_restore) \
-              -previous-image=$(resources.outputs.image.url) \
+              -previous-image=$(params.docker_registry_repository) \
               -run-image=$(params.run_image) \
-              $(resources.outputs.image.url)
+              $(params.image)
 
         buildTaskSteps:
           - name: build-hello-world
             image: node:22
             imagePullPolicy: IfNotPresent
-            workingDir: $(resources.inputs.app.path)
+            workingDir: $(workspaces.source.path)
             script: |
               #!/bin/bash
               echo "hello world"

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0-dev.50
+version: 2.0.0-dev.51
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.0.0-dev.49
+version: 2.0.0-dev.50
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 0.1.49](https://img.shields.io/badge/Version-0.1.49-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.0.0-dev.54](https://img.shields.io/badge/Version-2.0.0--dev.54-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 
@@ -120,7 +120,7 @@ buildpacks:
         - name: build-hello-world
           image: node:22
           imagePullPolicy: IfNotPresent
-          workingDir: $(resources.inputs.app.path)
+          workingDir: $(workspaces.source.path)
           script: |
             #!/bin/bash
             echo "hello world"
@@ -128,7 +128,7 @@ buildpacks:
         - name: pre-deploy-hello-world
           image: node:22
           imagePullPolicy: IfNotPresent
-          workingDir: $(resources.inputs.app.path)
+          workingDir: $(workspaces.source.path)
           script: |
             #!/bin/bash
             echo "hello world"
@@ -136,7 +136,7 @@ buildpacks:
         - name: post-deploy-hello-world
           image: node:22
           imagePullPolicy: IfNotPresent
-          workingDir: $(resources.inputs.app.path)
+          workingDir: $(workspaces.source.path)
           script: |
             #!/bin/bash
             echo "hello world"
@@ -158,7 +158,7 @@ buildpacks:
         name: build
         image: node:22
         imagePullPolicy: IfNotPresent
-        workingDir: $(resources.inputs.app.path)
+        workingDir: $(workspaces.source.path)
         script: |
           #!/bin/bash
           az login --identity --username <managed-indentity>
@@ -175,15 +175,15 @@ buildpacks:
             -gid=$(params.group_id) \
             -process-type=$(params.process_type) \
             -skip-restore=$(params.skip_restore) \
-            -previous-image=$(resources.outputs.image.url) \
+            -previous-image=$(params.docker_registry_repository) \
             -run-image=$(params.run_image) \
-            $(resources.outputs.image.url)
+            $(params.image)
 
       buildTaskSteps:
         - name: build-hello-world
           image: node:22
           imagePullPolicy: IfNotPresent
-          workingDir: $(resources.inputs.app.path)
+          workingDir: $(workspaces.source.path)
           script: |
             #!/bin/bash
             echo "hello world"
@@ -214,7 +214,7 @@ After configuring these values, you will have an extra `sentry-release` step aft
 
 | Key | Type | Default | Description |
 |-----|------|---------|-------------|
-| buildpacks.cnbPlatformAPI | string | `"0.4"` | cnb (cloud native buildpacks) platform API to support see more details [here](https://buildpacks.io/docs/reference/spec/platform-api/) and [here](https://github.com/buildpacks/spec/blob/main/platform.md) |
+| buildpacks.cnbPlatformAPI | string | `"0.10"` | cnb (cloud native buildpacks) platform API to support see more details [here](https://buildpacks.io/docs/reference/spec/platform-api/) and [here](https://github.com/buildpacks/spec/blob/main/platform.md) |
 | buildpacks.enabled | bool | `false` | should we enable buildpack based pipelines |
 | buildpacks.generate.buildpackDjangoBuildPipeline.buildTaskName | string | `"buildpack-django"` | the generated name of the tekton task implementing the "build" step |
 | buildpacks.generate.buildpackDjangoBuildPipeline.buildTaskSteps | list | see values.yaml for the default values of it | steps to run in the `buildpack-django` task prior to executing /cnb/lifecycle/creator CLI |
@@ -263,16 +263,16 @@ After configuring these values, you will have an extra `sentry-release` step aft
 | buildpacks.generate.buildpackRubyBuildPipeline.preDeployTaskSteps | list | `[]` | steps to run in the `pre-deploy` task prior to ArgoCD sync command can be useful to prepare different backups and tests before real deploy |
 | imagePullPolicy | string | `"IfNotPresent"` | default imagePullPolicy to be used for images pulled in tekton task steps |
 | images | object | See below | default images used in our solution |
-| images.argocd_cli | string | `"https://github.com/argoproj/argo-cd/releases/download/v2.3.4/argocd-linux-amd64"` | argocd cli downdload URL |
+| images.argocd_cli | string | `"https://github.com/argoproj/argo-cd/releases/download/v2.14.15/argocd-linux-amd64"` | argocd cli downdload URL |
 | images.awscli | string | `"docker.io/amazon/aws-cli:2.7.4"` | aws cli image (used for aws ecr auth) |
-| images.bash | string | `"docker.io/library/bash:5.1.8"` | bash image (used for various ops in steps) |
-| images.git | string | `"alpine/git:v2.32.0"` | git image |
-| images.kaniko | string | `"gcr.io/kaniko-project/executor@sha256:b44b0744b450e731b5a5213058792cd8d3a6a14c119cf6b1f143704f22a7c650"` | kaniko image used to build containers containing docker files - v1.8.1, uploaded April 5 2022 |
-| images.kubectl | string | `"bitnami/kubectl:1.22.10"` | kubectl cli |
+| images.bash | string | `"docker.io/library/bash:5.2.37"` | bash image (used for various ops in steps) |
+| images.git | string | `"alpine/git:v2.49.0"` | git image |
+| images.kaniko | string | `"gcr.io/kaniko-project/executor@sha256:4e7a52dd1f14872430652bb3b027405b8dfd17c4538751c620ac005741ef9698"` | kaniko image used to build containers containing docker files - v1.24.0, uploaded May 23 2025 |
+| images.kubectl | string | `"bitnami/kubectl:1.33.1"` | kubectl cli |
 | images.kubeval | string | `"public.ecr.aws/saritasa/kubeval:0.16.1"` | kubeval image - validate Kubernetes manifests |
-| images.kustomize | string | `"registry.k8s.io/kustomize/kustomize:v5.0.0"` | kustomize cli |
+| images.kustomize | string | `"registry.k8s.io/kustomize/kustomize:v5.6.0"` | kustomize cli |
 | images.python | string | `"saritasallc/python3:0.4"` | python image |
-| images.sentry_cli | string | `"getsentry/sentry-cli:2.19.1"` | sentry cli image - needs to prepare Sentry releases |
+| images.sentry_cli | string | `"getsentry/sentry-cli:2.46.0"` | sentry cli image - needs to prepare Sentry releases |
 | images.slack | string | `"cloudposse/slack-notifier:0.4.0"` | slack notifier |
 | images.yamlfix | string | `"public.ecr.aws/saritasa/yamlfix:1.8.1"` | yamlfix image - format yaml files |
 | kaniko.enabled | bool | `false` | should we enable the kaniko pipeline |

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.0.0-dev.54](https://img.shields.io/badge/Version-2.0.0--dev.54-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/TODO
+++ b/charts/tekton-pipelines/TODO
@@ -1,0 +1,1 @@
+Remove the spec.resources from the Buildpack TriggerTemplate

--- a/charts/tekton-pipelines/TODO
+++ b/charts/tekton-pipelines/TODO
@@ -1,1 +1,0 @@
-Remove the spec.resources from the Buildpack TriggerTemplate

--- a/charts/tekton-pipelines/templates/_snippets.tpl
+++ b/charts/tekton-pipelines/templates/_snippets.tpl
@@ -175,41 +175,6 @@
   value: "$(tt.params.environment)"
 {{- end}}
 
-
-# ┌──────────────────────────────────────────────────────────────────────────────┐
-# │ Default resources for the pipeline run. Defined in trigger template          │
-# │ - app: our git repository with the code we're building                       │
-# │ - kubernetes-repo: out git repo containing kube manifests                    │
-# │ - image: docker registry image                                               │
-# │                                                                              │
-# └──────────────────────────────────────────────────────────────────────────────┘
-{{- define "pipeline.defaultResources" -}}
-- name: app
-  resourceSpec:
-    type: git
-    params:
-      - name: url
-        value: $(tt.params.repository_ssh_url)
-      - name: revision
-        value: $(tt.params.head_commit)
-      - name: submodules
-        value: $(tt.params.repository_submodules)
-- name: kubernetes-repo
-  resourceSpec:
-    type: git
-    params:
-      - name: url
-        value: $(tt.params.kubernetes_repository_ssh_url)
-      - name: revision
-        value: $(tt.params.kubernetes_branch)
-- name: image
-  resourceSpec:
-    type: image
-    params:
-      - name: url
-        value: $(tt.params.docker_registry_repository):$(tt.params.environment)-$(tt.params.sha)
-{{- end}}
-
 # ┌──────────────────────────────────────────────────────────────────────────────┐
 # │ Default workspaces associated with tekton pipeline runs                      │
 # │ - source: contains app git repo source code cloned by tekton                 │
@@ -247,10 +212,13 @@ finally:
         value: "$(params.pusher_avatar)"
       - name: pusher_url
         value: "$(params.pusher_url)"
+
+      # TODO: check if we need to remove this or not
       - name: repository_url
         value: "$(params.repository_url)"
       - name: branch
         value: "$(params.branch)"
+      ##
       - name: environment
         value: "$(params.environment)"
       - name: status
@@ -265,10 +233,6 @@ finally:
 - name: sentry-release
   taskRef:
     name:  sentry-release
-  resources:
-    inputs:
-      - name: app
-        resource: app
   params:
     - name: environment
       value: "$(params.environment)"
@@ -291,10 +255,6 @@ finally:
 - name: pre-deploy
   taskRef:
     name:  {{ .name }}
-  resources:
-    inputs:
-      - name: app
-        resource: app
   params:
     - name: application
       value: "$(params.application)"

--- a/charts/tekton-pipelines/templates/_snippets.tpl
+++ b/charts/tekton-pipelines/templates/_snippets.tpl
@@ -212,13 +212,10 @@ finally:
         value: "$(params.pusher_avatar)"
       - name: pusher_url
         value: "$(params.pusher_url)"
-
-      # TODO: check if we need to remove this or not
       - name: repository_url
         value: "$(params.repository_url)"
       - name: branch
         value: "$(params.branch)"
-      ##
       - name: environment
         value: "$(params.environment)"
       - name: status

--- a/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
@@ -20,10 +20,18 @@ spec:
       type: string
       description: project's namespace
 
+    - name: repository_ssh_url
+      type: string
+      description: git repository ssh url
+
     - name: repository_submodules
       type: string
       description: defines whether repository should be initialized with submodules or not (if false value is set, it means no repository submodules would be downloaded)
       default: "true"
+
+    - name: kubernetes_repository_ssh_url
+      type: string
+      description: git repository ssh url for kubernetes manifests repo
 
     - name: add_tag_latest
       type: string
@@ -84,22 +92,22 @@ spec:
   workspaces:
     - name: source
 
-  resources:
-    - name: app
-      type: git
-    - name: kubernetes-repo
-      type: git
-    - name: image
-      type: image
-
   tasks:
+    - name: git-clone-catalog
+      taskRef:
+        name: git-clone-catalog
+      workspaces:
+      - name: output
+        workspace: source
+      params:
+      - name: url
+        value: $(params.repository_ssh_url)
+      - name: revision
+        value: $(params.branch)
+
     - name: prepare-build
       taskRef:
         name: buildpack-prepare-build
-      resources:
-        inputs:
-          - name: app
-            resource: app
       params:
         - name: application
           value: "$(params.application)"
@@ -112,30 +120,24 @@ spec:
       workspaces:
         - name: source
           workspace: source
+      runAfter:
+        - git-clone-catalog
 
     - name: detect-nodejs-version
       taskRef:
         name: detect-nodejs-version
-      resources:
-        inputs:
-          - name: app
-            resource: app
       params:
         - name: default_version
           value: "14"
+      workspaces:
+        - name: source
+          workspace: source
       runAfter:
         - prepare-build
 
     - name: {{ .pipeline.buildTaskName }}
       taskRef:
         name: {{ .pipeline.buildTaskName }}
-      resources:
-          inputs:
-            - name: app
-              resource: app
-          outputs:
-              - name: image
-                resource: image
       params:
         - name: application
           value: "$(params.application)"
@@ -173,19 +175,31 @@ spec:
           value: "$(params.environment)"
         - name: sourcemaps_dir
           value: "$(params.sourcemaps_dir)"
+        - name: image
+          value: "$(params.docker_registry_repository):$(params.environment)-$(params.sha)"
       workspaces:
-        - name: source
+        - name: app
           workspace: source
       runAfter:
         - detect-nodejs-version
 
+    - name: git-clone-kubernetes
+      taskRef:
+        name: git-clone-catalog
+      params:
+        - name: url
+          value: $(params.kubernetes_repository_ssh_url)
+        - name: revision
+          value: $(params.kubernetes_branch)
+      workspaces:
+        - name: output
+          workspace: source
+      runAfter:
+        - {{ .pipeline.buildTaskName }}
+
     - name: kustomize
       taskRef:
         name: kustomize
-      resources:
-        inputs:
-          - name: kubernetes-repo
-            resource: kubernetes-repo
       params:
         - name: application
           value: "$(params.application)"
@@ -197,8 +211,11 @@ spec:
           value: "$(params.kubernetes_branch)"
         - name: environment
           value: "$(params.environment)"
+      workspaces:
+        - name: source
+          workspace: source
       runAfter:
-        - {{ .pipeline.buildTaskName }}
+        - git-clone-kubernetes
 
   {{- if (.pipeline).preDeployTaskSteps }}
   {{ include "pipeline.preDeploy" (dict "name" (printf "%s-pre-deploy" .pipeline.name)) | nindent 4 }}
@@ -220,6 +237,5 @@ spec:
   {{ include "pipeline.postDeploy" (dict "name" (printf "%s-post-deploy" .pipeline.name) "sentry_enabled" .sentry.enabled) | nindent 4 }}
 
   {{ include "pipeline.finalNotification" . | nindent 2 }}
-
 ---
 {{- end }}

--- a/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
@@ -93,9 +93,9 @@ spec:
     - name: source
 
   tasks:
-    - name: git-clone-catalog
+    - name: git-clone
       taskRef:
-        name: git-clone-catalog
+        name: git-clone
       workspaces:
       - name: output
         workspace: source
@@ -121,14 +121,14 @@ spec:
         - name: source
           workspace: source
       runAfter:
-        - git-clone-catalog
+        - git-clone
 
     - name: detect-nodejs-version
       taskRef:
         name: detect-nodejs-version
       params:
         - name: default_version
-          value: "14"
+          value: "22"
       workspaces:
         - name: source
           workspace: source
@@ -183,9 +183,9 @@ spec:
       runAfter:
         - detect-nodejs-version
 
-    - name: git-clone-kubernetes
+    - name: git-clone-gitops-repository
       taskRef:
-        name: git-clone-catalog
+        name: git-clone
       params:
         - name: url
           value: $(params.kubernetes_repository_ssh_url)
@@ -215,7 +215,7 @@ spec:
         - name: source
           workspace: source
       runAfter:
-        - git-clone-kubernetes
+        - git-clone-gitops-repository
 
   {{- if (.pipeline).preDeployTaskSteps }}
   {{ include "pipeline.preDeploy" (dict "name" (printf "%s-pre-deploy" .pipeline.name)) | nindent 4 }}

--- a/charts/tekton-pipelines/templates/buildpacks/tasks/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/tasks/_buildpack.yaml
@@ -9,15 +9,7 @@ spec:
     {{- .pipeline.description | default (printf "The Buildpacks %s task builds source into a container image and pushes it to a AWS ECR registry, using Cloud Native Buildpacks" (.pipeline.buildTaskName)) | nindent 4}}
 
   workspaces:
-    - name: source
-
-  resources:
-    inputs:
-      - name: app
-        type: git
-    outputs:
-      - name: image
-        type: image
+    - name: app
 
   params:
     - name: application
@@ -121,6 +113,10 @@ spec:
       description: name of the dir where frontend sourcemaps would be stored in workspace
       default: "sourcemaps"
 
+    - name: image
+      type: string
+      description: new image for the application
+
   stepTemplate:
     env:
       - name: CNB_PLATFORM_API
@@ -140,9 +136,8 @@ spec:
           chown -R "$(params.user_id):$(params.group_id)" "/tekton/home" &&
           chown -R "$(params.user_id):$(params.group_id)" "/layers" &&
           chown -R "$(params.user_id):$(params.group_id)" "/cache" &&
-          chown -R "$(params.user_id):$(params.group_id)" "$(workspaces.source.path)"
-          chown -R "$(params.user_id):$(params.group_id)" "$(resources.inputs.app.path)"
-          chmod -R g+w "$(resources.inputs.app.path)"
+          chown -R "$(params.user_id):$(params.group_id)" "$(workspaces.app.path)"
+          chmod -R g+w "$(workspaces.app.path)"
       volumeMounts:
         - name: layers-dir
           mountPath: /layers
@@ -168,7 +163,7 @@ spec:
       image: $(params.builder_image)
       imagePullPolicy: {{ .imagePullPolicy }}
       resources: {}
-      workingDir: $(resources.inputs.app.path)
+      workingDir: $(workspaces.app.path)
       script: |
         #!/bin/bash
 
@@ -184,17 +179,17 @@ spec:
           -project-metadata=project.toml \
           -cache-dir=/cache \
           -layers=/layers \
-          -platform=$(workspaces.source.path)/$(params.platform_dir) \
+          -platform=$(workspaces.app.path)/$(params.platform_dir) \
           -report=/layers/report.toml \
           -cache-image=$(params.cache_image) \
           -uid=$(params.user_id) \
           -gid=$(params.group_id) \
           -process-type=$(params.process_type) \
           -skip-restore=$(params.skip_restore) \
-          -previous-image=$(resources.outputs.image.url) \
+          -previous-image=$(params.docker_registry_repository) \
           -run-image=$(params.run_image) \
           ${ADDITIONAL_TAG} \
-          $(resources.outputs.image.url)
+          $(params.image)
 
       volumeMounts:
         - name: layers-dir

--- a/charts/tekton-pipelines/templates/buildpacks/tasks/prepare-buildpack-build.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/tasks/prepare-buildpack-build.yaml
@@ -34,11 +34,6 @@ spec:
   workspaces:
     - name: source
 
-  resources:
-    inputs:
-      - name: app
-        type: git
-
   params:
     - name: application
       type: string
@@ -64,7 +59,7 @@ spec:
       script: |
         #!/usr/bin/env bash
 
-        path=$(resources.inputs.app.path)
+        path=$(workspaces.source.path)
 
         # rename `buildpack_config_filename` file to `buildpack.yml` and
         # `project_config_filename` to `project.toml` if they are not equal to
@@ -103,7 +98,7 @@ spec:
 
         import toml, os, sys
 
-        source_path = "$(resources.inputs.app.path)/project.toml"
+        source_path = "$(workspaces.source.path)/project.toml"
         env_dir = "$(workspaces.source.path)/$(params.platform_dir)/env"
 
         try:

--- a/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
@@ -1,5 +1,5 @@
 {{- define "trigger-template.buildpack" -}}
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
   name: {{ .pipeline.name }}-trigger-template
@@ -77,9 +77,11 @@ spec:
         component: $(tt.params.component)
     spec:
       serviceAccountName: $(tt.params.application)-build-pipeline-sa
-      serviceAccountNames:
-        - taskName: kustomize
-          serviceAccountName: $(tt.params.application)-build-pipeline-kustomize-sa
+      taskRunSpecs:
+        - pipelineTaskName: kustomize
+          taskServiceAccountName: $(tt.params.application)-build-pipeline-kustomize-sa
+        - pipelineTaskName: git-clone-kubernetes
+          taskServiceAccountName: $(tt.params.application)-build-pipeline-kustomize-sa
       pipelineRef:
         name: {{ .pipeline.name }}
       params:
@@ -88,6 +90,12 @@ spec:
           value: "$(tt.params.project)"
         - name: namespace
           value: "$(tt.params.namespace)"
+        - name: git_url
+          value: "$(tt.params.repository_url)"
+        - name: repository_ssh_url
+          value: "$(tt.params.repository_ssh_url)"
+        - name: git_revision
+          value: "$(tt.params.head_commit)"
         - name: buildpack_builder_image
           value: "$(tt.params.buildpack_builder_image)"
         - name: buildpack_runner_image
@@ -110,9 +118,8 @@ spec:
           value: "$(tt.params.buildpack_cnb_platform_api)"
         - name: sentry_project_name
           value: "$(tt.params.sentry_project_name)"
-
-      resources:
-        {{- include "pipeline.defaultResources" . | nindent 8 }}
+        - name: kubernetes_repository_ssh_url
+          value: "$(tt.params.kubernetes_repository_ssh_url)"
 
       workspaces:
         {{- include "pipeline.defaultWorkspaces" . | nindent 8 }}

--- a/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
@@ -80,7 +80,7 @@ spec:
       taskRunSpecs:
         - pipelineTaskName: kustomize
           taskServiceAccountName: $(tt.params.application)-build-pipeline-kustomize-sa
-        - pipelineTaskName: git-clone-kubernetes
+        - pipelineTaskName: git-clone-gitops-repository
           taskServiceAccountName: $(tt.params.application)-build-pipeline-kustomize-sa
       pipelineRef:
         name: {{ .pipeline.name }}

--- a/charts/tekton-pipelines/templates/common/tasks/_pre-deploy.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/_pre-deploy.yaml
@@ -13,11 +13,6 @@ spec:
   workspaces:
     - name: source
 
-  resources:
-    inputs:
-      - name: app
-        type: git
-
   params:
     - name: application
       type: string

--- a/charts/tekton-pipelines/templates/common/tasks/detect-nodejs-version.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/detect-nodejs-version.yaml
@@ -35,8 +35,8 @@ spec:
           exit 0
         fi
 
-        # if no engine is defined we use node:14 as the default image
-        node_ver=$(cat package.json | jq -r ".engines.node // 14" | sed 's/[\^>~=]//g')
+        # if no engine is defined we use node:$(params.default_version) as the default image
+        node_ver=$(cat package.json | jq -r ".engines.node // $(params.default_version)" | sed 's/[\^>~=]//g')
 
         # store in the results
         # which we will use as the image:"node:version" in build task

--- a/charts/tekton-pipelines/templates/common/tasks/detect-nodejs-version.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/detect-nodejs-version.yaml
@@ -7,10 +7,9 @@ spec:
   description: >-
     Nodejs version detected from package.json
 
-  resources:
-    inputs:
-      - name: app
-        type: git
+  workspaces:
+    - name: source
+      description: The git repo will be cloned onto the volume backing this Workspace.
 
   params:
     - name: default_version
@@ -25,7 +24,7 @@ spec:
     - name: get-nodejs-version
       image: cfmanteiga/alpine-bash-curl-jq
       imagePullPolicy: {{ .Values.imagePullPolicy }}
-      workingDir: $(resources.inputs.app.path)
+      workingDir: $(workspaces.source.path)
       script: |
         #!/usr/bin/env bash
         set -Eeo pipefail

--- a/charts/tekton-pipelines/templates/common/tasks/git-clone-catalog.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/git-clone-catalog.yaml
@@ -1,0 +1,244 @@
+# https://github.com/tektoncd/catalog/blob/main/task/git-clone/0.9/git-clone.yaml
+# Provided by tekton
+apiVersion: tekton.dev/v1beta1
+kind: Task
+metadata:
+  name: git-clone-catalog
+  labels:
+    app.kubernetes.io/version: "0.9"
+  annotations:
+    tekton.dev/pipelines.minVersion: "0.38.0"
+    tekton.dev/categories: Git
+    tekton.dev/tags: git
+    tekton.dev/displayName: "git clone"
+    tekton.dev/platforms: "linux/amd64,linux/s390x,linux/ppc64le,linux/arm64"
+spec:
+  description: >-
+    These Tasks are Git tasks to work with repositories used by other tasks
+    in your Pipeline.
+
+    The git-clone Task will clone a repo from the provided url into the
+    output Workspace. By default the repo will be cloned into the root of
+    your Workspace. You can clone into a subdirectory by setting this Task's
+    subdirectory param. This Task also supports sparse checkouts. To perform
+    a sparse checkout, pass a list of comma separated directory patterns to
+    this Task's sparseCheckoutDirectories param.
+  workspaces:
+    - name: output
+      description: The git repo will be cloned onto the volume backing this Workspace.
+    - name: ssh-directory
+      optional: true
+      description: |
+        A .ssh directory with private key, known_hosts, config, etc. Copied to
+        the user's home before git commands are executed. Used to authenticate
+        with the git remote when performing the clone. Binding a Secret to this
+        Workspace is strongly recommended over other volume types.
+    - name: basic-auth
+      optional: true
+      description: |
+        A Workspace containing a .gitconfig and .git-credentials file. These
+        will be copied to the user's home before any git commands are run. Any
+        other files in this Workspace are ignored. It is strongly recommended
+        to use ssh-directory over basic-auth whenever possible and to bind a
+        Secret to this Workspace over other volume types.
+    - name: ssl-ca-directory
+      optional: true
+      description: |
+        A workspace containing CA certificates, this will be used by Git to
+        verify the peer with when fetching or pushing over HTTPS.
+  params:
+    - name: url
+      description: Repository URL to clone from.
+      type: string
+    - name: revision
+      description: Revision to checkout. (branch, tag, sha, ref, etc...)
+      type: string
+      default: ""
+    - name: refspec
+      description: Refspec to fetch before checking out revision.
+      default: ""
+    - name: submodules
+      description: Initialize and fetch git submodules.
+      type: string
+      default: "true"
+    - name: depth
+      description: Perform a shallow clone, fetching only the most recent N commits.
+      type: string
+      default: "1"
+    - name: sslVerify
+      description: Set the `http.sslVerify` global git config. Setting this to `false` is not advised unless you are sure that you trust your git remote.
+      type: string
+      default: "true"
+    - name: crtFileName
+      description: file name of mounted crt using ssl-ca-directory workspace. default value is ca-bundle.crt.
+      type: string
+      default: "ca-bundle.crt"
+    - name: subdirectory
+      description: Subdirectory inside the `output` Workspace to clone the repo into.
+      type: string
+      default: ""
+    - name: sparseCheckoutDirectories
+      description: Define the directory patterns to match or exclude when performing a sparse checkout.
+      type: string
+      default: ""
+    - name: deleteExisting
+      description: Clean out the contents of the destination directory if it already exists before cloning.
+      type: string
+      default: "true"
+    - name: httpProxy
+      description: HTTP proxy server for non-SSL requests.
+      type: string
+      default: ""
+    - name: httpsProxy
+      description: HTTPS proxy server for SSL requests.
+      type: string
+      default: ""
+    - name: noProxy
+      description: Opt out of proxying HTTP/HTTPS requests.
+      type: string
+      default: ""
+    - name: verbose
+      description: Log the commands that are executed during `git-clone`'s operation.
+      type: string
+      default: "true"
+    - name: gitInitImage
+      description: The image providing the git-init binary that this Task runs.
+      type: string
+      default: "gcr.io/tekton-releases/github.com/tektoncd/pipeline/cmd/git-init:v0.40.2"
+    - name: userHome
+      description: |
+        Absolute path to the user's home directory.
+      type: string
+      default: "/home/git"
+  results:
+    - name: commit
+      description: The precise commit SHA that was fetched by this Task.
+    - name: url
+      description: The precise URL that was fetched by this Task.
+    - name: committer-date
+      description: The epoch timestamp of the commit that was fetched by this Task.
+  steps:
+    - name: clone
+      image: "$(params.gitInitImage)"
+      env:
+      - name: HOME
+        value: "$(params.userHome)"
+      - name: PARAM_URL
+        value: $(params.url)
+      - name: PARAM_REVISION
+        value: $(params.revision)
+      - name: PARAM_REFSPEC
+        value: $(params.refspec)
+      - name: PARAM_SUBMODULES
+        value: $(params.submodules)
+      - name: PARAM_DEPTH
+        value: $(params.depth)
+      - name: PARAM_SSL_VERIFY
+        value: $(params.sslVerify)
+      - name: PARAM_CRT_FILENAME
+        value: $(params.crtFileName)
+      - name: PARAM_SUBDIRECTORY
+        value: $(params.subdirectory)
+      - name: PARAM_DELETE_EXISTING
+        value: $(params.deleteExisting)
+      - name: PARAM_HTTP_PROXY
+        value: $(params.httpProxy)
+      - name: PARAM_HTTPS_PROXY
+        value: $(params.httpsProxy)
+      - name: PARAM_NO_PROXY
+        value: $(params.noProxy)
+      - name: PARAM_VERBOSE
+        value: $(params.verbose)
+      - name: PARAM_SPARSE_CHECKOUT_DIRECTORIES
+        value: $(params.sparseCheckoutDirectories)
+      - name: PARAM_USER_HOME
+        value: $(params.userHome)
+      - name: WORKSPACE_OUTPUT_PATH
+        value: $(workspaces.output.path)
+      - name: WORKSPACE_SSH_DIRECTORY_BOUND
+        value: $(workspaces.ssh-directory.bound)
+      - name: WORKSPACE_SSH_DIRECTORY_PATH
+        value: $(workspaces.ssh-directory.path)
+      - name: WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND
+        value: $(workspaces.basic-auth.bound)
+      - name: WORKSPACE_BASIC_AUTH_DIRECTORY_PATH
+        value: $(workspaces.basic-auth.path)
+      - name: WORKSPACE_SSL_CA_DIRECTORY_BOUND
+        value: $(workspaces.ssl-ca-directory.bound)
+      - name: WORKSPACE_SSL_CA_DIRECTORY_PATH
+        value: $(workspaces.ssl-ca-directory.path)
+      securityContext:
+        runAsNonRoot: true
+        runAsUser: 65532
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+
+        if [ "${PARAM_VERBOSE}" = "true" ] ; then
+          set -x
+        fi
+
+        if [ "${WORKSPACE_BASIC_AUTH_DIRECTORY_BOUND}" = "true" ] ; then
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.git-credentials" "${PARAM_USER_HOME}/.git-credentials"
+          cp "${WORKSPACE_BASIC_AUTH_DIRECTORY_PATH}/.gitconfig" "${PARAM_USER_HOME}/.gitconfig"
+          chmod 400 "${PARAM_USER_HOME}/.git-credentials"
+          chmod 400 "${PARAM_USER_HOME}/.gitconfig"
+        fi
+
+        if [ "${WORKSPACE_SSH_DIRECTORY_BOUND}" = "true" ] ; then
+          cp -R "${WORKSPACE_SSH_DIRECTORY_PATH}" "${PARAM_USER_HOME}"/.ssh
+          chmod 700 "${PARAM_USER_HOME}"/.ssh
+          chmod -R 400 "${PARAM_USER_HOME}"/.ssh/*
+        fi
+
+        if [ "${WORKSPACE_SSL_CA_DIRECTORY_BOUND}" = "true" ] ; then
+           export GIT_SSL_CAPATH="${WORKSPACE_SSL_CA_DIRECTORY_PATH}"
+           if [ "${PARAM_CRT_FILENAME}" != "" ] ; then
+              export GIT_SSL_CAINFO="${WORKSPACE_SSL_CA_DIRECTORY_PATH}/${PARAM_CRT_FILENAME}"
+           fi
+        fi
+        CHECKOUT_DIR="${WORKSPACE_OUTPUT_PATH}/${PARAM_SUBDIRECTORY}"
+
+        cleandir() {
+          # Delete any existing contents of the repo directory if it exists.
+          #
+          # We don't just "rm -rf ${CHECKOUT_DIR}" because ${CHECKOUT_DIR} might be "/"
+          # or the root of a mounted volume.
+          if [ -d "${CHECKOUT_DIR}" ] ; then
+            # Delete non-hidden files and directories
+            rm -rf "${CHECKOUT_DIR:?}"/*
+            # Delete files and directories starting with . but excluding ..
+            rm -rf "${CHECKOUT_DIR}"/.[!.]*
+            # Delete files and directories starting with .. plus any other character
+            rm -rf "${CHECKOUT_DIR}"/..?*
+          fi
+        }
+
+        if [ "${PARAM_DELETE_EXISTING}" = "true" ] ; then
+          cleandir || true
+        fi
+
+        test -z "${PARAM_HTTP_PROXY}" || export HTTP_PROXY="${PARAM_HTTP_PROXY}"
+        test -z "${PARAM_HTTPS_PROXY}" || export HTTPS_PROXY="${PARAM_HTTPS_PROXY}"
+        test -z "${PARAM_NO_PROXY}" || export NO_PROXY="${PARAM_NO_PROXY}"
+
+        git config --global --add safe.directory "${WORKSPACE_OUTPUT_PATH}"
+        /ko-app/git-init \
+          -url="${PARAM_URL}" \
+          -revision="${PARAM_REVISION}" \
+          -refspec="${PARAM_REFSPEC}" \
+          -path="${CHECKOUT_DIR}" \
+          -sslVerify="${PARAM_SSL_VERIFY}" \
+          -submodules="${PARAM_SUBMODULES}" \
+          -depth="${PARAM_DEPTH}" \
+          -sparseCheckoutDirectories="${PARAM_SPARSE_CHECKOUT_DIRECTORIES}"
+        cd "${CHECKOUT_DIR}"
+        RESULT_SHA="$(git rev-parse HEAD)"
+        EXIT_CODE="$?"
+        if [ "${EXIT_CODE}" != 0 ] ; then
+          exit "${EXIT_CODE}"
+        fi
+        RESULT_COMMITTER_DATE="$(git log -1 --pretty=%ct)"
+        printf "%s" "${RESULT_COMMITTER_DATE}" > "$(results.committer-date.path)"
+        printf "%s" "${RESULT_SHA}" > "$(results.commit.path)"
+        printf "%s" "${PARAM_URL}" > "$(results.url.path)"

--- a/charts/tekton-pipelines/templates/common/tasks/git-clone.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/git-clone.yaml
@@ -3,7 +3,7 @@
 apiVersion: tekton.dev/v1beta1
 kind: Task
 metadata:
-  name: git-clone-catalog
+  name: git-clone
   labels:
     app.kubernetes.io/version: "0.9"
   annotations:

--- a/charts/tekton-pipelines/templates/common/tasks/kustomize.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/kustomize.yaml
@@ -45,7 +45,7 @@ spec:
         git config user.name "tekton-kustomize"
 
     - name: update-image
-      image: {{ .Values.images.kustomize | default "registry.k8s.io/kustomize/kustomize:v5.0.0"}}
+      image: {{ .Values.images.kustomize | default "registry.k8s.io/kustomize/kustomize:v5.6.0"}}
       imagePullPolicy: {{ .Values.imagePullPolicy }}
       workingDir: $(workspaces.source.path)
       script: |

--- a/charts/tekton-pipelines/templates/common/tasks/kustomize.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/kustomize.yaml
@@ -41,6 +41,7 @@ spec:
       imagePullPolicy: {{ .Values.imagePullPolicy }}
       workingDir: $(workspaces.source.path)
       script: |
+        git config --global --add safe.directory $(workspaces.source.path)
         git config user.email "$DEVOPS_GROUP_EMAIL"
         git config user.name "tekton-kustomize"
 
@@ -88,6 +89,7 @@ spec:
       workingDir: $(workspaces.source.path)
       script: |
         set +x
+        git config --global --add safe.directory $(workspaces.source.path)
         git checkout $(params.kubernetes_branch)
 
         # apply changes only if it exists, otherwise do nothing

--- a/charts/tekton-pipelines/templates/common/tasks/kustomize.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/kustomize.yaml
@@ -7,10 +7,8 @@ spec:
   description: >-
     Updates image tag in the kustomize overlay of the app
 
-  resources:
-    inputs:
-      - name: kubernetes-repo
-        type: git
+  workspaces:
+    - name: source
 
   params:
     - name: application
@@ -41,7 +39,7 @@ spec:
     - name: git-set-user
       image: {{ .Values.images.git | default "alpine/git:latest" }}
       imagePullPolicy: {{ .Values.imagePullPolicy }}
-      workingDir: $(resources.inputs.kubernetes-repo.path)
+      workingDir: $(workspaces.source.path)
       script: |
         git config user.email "$DEVOPS_GROUP_EMAIL"
         git config user.name "tekton-kustomize"
@@ -49,7 +47,7 @@ spec:
     - name: update-image
       image: {{ .Values.images.kustomize | default "registry.k8s.io/kustomize/kustomize:v5.0.0"}}
       imagePullPolicy: {{ .Values.imagePullPolicy }}
-      workingDir: $(resources.inputs.kubernetes-repo.path)
+      workingDir: $(workspaces.source.path)
       script: |
         app=$(params.application)
         env=$(params.environment)
@@ -60,7 +58,7 @@ spec:
     - name: yamlfix
       image: {{ .Values.images.yamlfix | default "public.ecr.aws/saritasa/yamlfix:latest"}}
       imagePullPolicy: {{ .Values.imagePullPolicy }}
-      workingDir: $(resources.inputs.kubernetes-repo.path)
+      workingDir: $(workspaces.source.path)
       script: |
         CONFIG=/workdir/yamlfix.toml
         if [ -f .yamlfix.toml ]; then
@@ -72,7 +70,7 @@ spec:
     - name: kubeval
       image: {{ .Values.images.kubeval | default "public.ecr.aws/saritasa/kubeval:latest"}}
       imagePullPolicy: {{ .Values.imagePullPolicy }}
-      workingDir: $(resources.inputs.kubernetes-repo.path)
+      workingDir: $(workspaces.source.path)
       script: |
         APISERVER=https://kubernetes.default.svc
         SERVICEACCOUNT=/var/run/secrets/kubernetes.io/serviceaccount
@@ -87,7 +85,7 @@ spec:
     - name: git-push
       image: {{ .Values.images.git | default "alpine/git:latest" }}
       imagePullPolicy: {{ .Values.imagePullPolicy }}
-      workingDir: $(resources.inputs.kubernetes-repo.path)
+      workingDir: $(workspaces.source.path)
       script: |
         set +x
         git checkout $(params.kubernetes_branch)

--- a/charts/tekton-pipelines/templates/common/tasks/sentry-release.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/sentry-release.yaml
@@ -12,11 +12,6 @@ spec:
   workspaces:
     - name: source
 
-  resources:
-    inputs:
-      - name: app
-        type: git
-
   params:
 
     - name: sentry_project_name
@@ -48,7 +43,7 @@ spec:
     - name: release
       image: {{ .Values.images.sentry_cli }}
       imagePullPolicy: {{ .Values.imagePullPolicy }}
-      workingDir: $(resources.inputs.app.path)
+      workingDir: $(workspaces.source.path)
       script: |
         #!/usr/bin/env sh
         set +x

--- a/charts/tekton-pipelines/templates/common/triggers/github-trigger-binding.yaml
+++ b/charts/tekton-pipelines/templates/common/triggers/github-trigger-binding.yaml
@@ -1,4 +1,4 @@
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerBinding
 metadata:
   name: github-trigger-binding

--- a/charts/tekton-pipelines/templates/kaniko/pipeline.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/pipeline.yaml
@@ -57,9 +57,9 @@ spec:
     - name: source
 
   tasks:
-    - name: git-clone-catalog
+    - name: git-clone
       taskRef:
-        name: git-clone-catalog
+        name: git-clone
       workspaces:
       - name: output
         workspace: source
@@ -92,11 +92,11 @@ spec:
         - name: source
           workspace: source
       runAfter:
-        - git-clone-catalog
+        - git-clone
 
-    - name: git-clone-kubernetes
+    - name: git-clone-gitops-repository
       taskRef:
-        name: git-clone-catalog
+        name: git-clone
       params:
         - name: url
           value: $(params.kubernetes_repository_ssh_url)
@@ -126,7 +126,7 @@ spec:
         - name: source
           workspace: source
       runAfter:
-        - git-clone-kubernetes
+        - git-clone-gitops-repository
 
   {{- if (.Values.kaniko).preDeployTaskSteps }}
   {{ include "pipeline.preDeploy" (dict "name" (printf "kaniko-pre-deploy")) | nindent 4 }}

--- a/charts/tekton-pipelines/templates/kaniko/pipeline.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/pipeline.yaml
@@ -21,6 +21,10 @@ spec:
       type: string
       description: project's namespace
 
+    - name: repository_ssh_url
+      type: string
+      description: git repository ssh url
+
     - name: docker_file
       type: string
       default: Dockerfile
@@ -45,28 +49,29 @@ spec:
       description: name of the dir where frontend sourcemaps would be stored in workspace
       default: "sourcemaps"
 
+    - name: kubernetes_repository_ssh_url
+      type: string
+      description: git repository ssh url for kubernetes manifests repo
+
   workspaces:
     - name: source
 
-  resources:
-    - name: app
-      type: git
-    - name: kubernetes-repo
-      type: git
-    - name: image
-      type: image
-
   tasks:
+    - name: git-clone-catalog
+      taskRef:
+        name: git-clone-catalog
+      workspaces:
+      - name: output
+        workspace: source
+      params:
+      - name: url
+        value: $(params.repository_ssh_url)
+      - name: revision
+        value: $(params.branch)
+
     - name: kaniko
       taskRef:
         name: kaniko
-      resources:
-          inputs:
-            - name: app
-              resource: app
-          outputs:
-              - name: image
-                resource: image
       params:
         - name: application
           value: "$(params.application)"
@@ -81,17 +86,31 @@ spec:
         - name: extra_args
           value:
             - $(params.kaniko_extra_args)
+        - name: image
+          value: "$(params.docker_registry_repository):$(params.environment)-$(params.sha)"
       workspaces:
         - name: source
           workspace: source
+      runAfter:
+        - git-clone-catalog
+
+    - name: git-clone-kubernetes
+      taskRef:
+        name: git-clone-catalog
+      params:
+        - name: url
+          value: $(params.kubernetes_repository_ssh_url)
+        - name: revision
+          value: $(params.kubernetes_branch)
+      workspaces:
+        - name: output
+          workspace: source
+      runAfter:
+        - kaniko
 
     - name: kustomize
       taskRef:
         name: kustomize
-      resources:
-        inputs:
-          - name: kubernetes-repo
-            resource: kubernetes-repo
       params:
         - name: application
           value: "$(params.application)"
@@ -103,8 +122,11 @@ spec:
           value: "$(params.kubernetes_branch)"
         - name: environment
           value: "$(params.environment)"
+      workspaces:
+        - name: source
+          workspace: source
       runAfter:
-        - kaniko
+        - git-clone-kubernetes
 
   {{- if (.Values.kaniko).preDeployTaskSteps }}
   {{ include "pipeline.preDeploy" (dict "name" (printf "kaniko-pre-deploy")) | nindent 4 }}

--- a/charts/tekton-pipelines/templates/kaniko/tasks/kaniko.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/tasks/kaniko.yaml
@@ -13,14 +13,6 @@ spec:
   workspaces:
     - name: source
 
-  resources:
-    inputs:
-      - name: app
-        type: git
-    outputs:
-      - name: image
-        type: image
-
   params:
     - name: application
       type: string
@@ -51,6 +43,10 @@ spec:
       type: string
       description: environment name of the app being built, i.e. dev/staging/prod
 
+    - name: image
+      type: string
+      description: new image for the application
+
   results:
     - name: password
       description: The password to authenticate to ecr registry.
@@ -64,7 +60,7 @@ spec:
     - name: authenticate
       image: {{ .Values.images.awscli | default "amazon/aws-cli:latest"}}
       imagePullPolicy: {{ .Values.imagePullPolicy }}
-      workingDir: $(resources.inputs.app.path)
+      workingDir: $(workspaces.source.path)
       script: |
         #!/bin/bash
         aws ecr get-login-password --region $AWS_REGION > $(results.password.path)
@@ -72,7 +68,7 @@ spec:
     - name: build
       image: {{ .Values.images.kaniko | default "gcr.io/kaniko-project/executor:latest"}}
       imagePullPolicy: {{ .Values.imagePullPolicy }}
-      workingDir: $(resources.inputs.app.path)
+      workingDir: $(workspaces.source.path)
       env:
         - name: "DOCKER_CONFIG"
           value: "/tekton/home/.docker/"
@@ -81,9 +77,9 @@ spec:
       args:
         - $(params.extra_args[*])
         - --build-arg=ENVIRONMENT=$(params.environment)
-        - --dockerfile=$(resources.inputs.app.path)/$(params.docker_file)
-        - --context=$(resources.inputs.app.path)/$(params.docker_context)
-        - --destination=$(resources.outputs.image.url)
+        - --dockerfile=$(workspaces.source.path)/$(params.docker_file)
+        - --context=$(workspaces.source.path)/$(params.docker_context)
+        - --destination=$(params.image)
         # - --verbosity=debug
 
       # kaniko assumes it is running as root, which means this example fails on platforms

--- a/charts/tekton-pipelines/templates/kaniko/trigger-template.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/trigger-template.yaml
@@ -53,7 +53,7 @@ spec:
       taskRunSpecs:
         - pipelineTaskName: kustomize
           taskServiceAccountName: $(tt.params.application)-build-pipeline-kustomize-sa
-        - pipelineTaskName: git-clone-kubernetes
+        - pipelineTaskName: git-clone-gitops-repository
           taskServiceAccountName: $(tt.params.application)-build-pipeline-kustomize-sa
       pipelineRef:
         name: kaniko-build-pipeline

--- a/charts/tekton-pipelines/templates/kaniko/trigger-template.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/trigger-template.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.kaniko.enabled }}
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
   name: kaniko-build-pipeline-trigger-template
@@ -49,9 +49,12 @@ spec:
         component: $(tt.params.component)
     spec:
       serviceAccountName: $(tt.params.application)-build-pipeline-sa
-      serviceAccountNames:
-        - taskName: kustomize
-          serviceAccountName: $(tt.params.application)-build-pipeline-kustomize-sa
+
+      taskRunSpecs:
+        - pipelineTaskName: kustomize
+          taskServiceAccountName: $(tt.params.application)-build-pipeline-kustomize-sa
+        - pipelineTaskName: git-clone-kubernetes
+          taskServiceAccountName: $(tt.params.application)-build-pipeline-kustomize-sa
       pipelineRef:
         name: kaniko-build-pipeline
       params:
@@ -60,6 +63,8 @@ spec:
           value: "$(tt.params.project)"
         - name: namespace
           value: "$(tt.params.namespace)"
+        - name: repository_ssh_url
+          value: "$(tt.params.repository_ssh_url)"
         - name: docker_file
           value: "$(tt.params.docker_file)"
         - name: docker_context
@@ -70,9 +75,8 @@ spec:
           value: "$(tt.params.repository_submodules)"
         - name: sentry_project_name
           value: "$(tt.params.sentry_project_name)"
-
-      resources:
-        {{- include "pipeline.defaultResources" . | nindent 8 }}
+        - name: kubernetes_repository_ssh_url
+          value: "$(tt.params.kubernetes_repository_ssh_url)"
 
       workspaces:
         {{- include "pipeline.defaultWorkspaces" . | nindent 8 }}

--- a/charts/tekton-pipelines/templates/wordpress/trigger-template.yaml
+++ b/charts/tekton-pipelines/templates/wordpress/trigger-template.yaml
@@ -1,5 +1,5 @@
 {{ if .Values.wordpress.enabled }}
-apiVersion: triggers.tekton.dev/v1alpha1
+apiVersion: triggers.tekton.dev/v1beta1
 kind: TriggerTemplate
 metadata:
   name: wordpress-build-pipeline-trigger-template

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -6,21 +6,21 @@
 # @default -- See below
 images:
   # -- argocd cli downdload URL
-  argocd_cli: https://github.com/argoproj/argo-cd/releases/download/v2.3.4/argocd-linux-amd64
+  argocd_cli: https://github.com/argoproj/argo-cd/releases/download/v2.14.15/argocd-linux-amd64
   # -- bash image (used for various ops in steps)
-  bash: docker.io/library/bash:5.1.8
+  bash: docker.io/library/bash:5.2.37
   # -- aws cli image (used for aws ecr auth)
   awscli: docker.io/amazon/aws-cli:2.7.4
-  # -- kaniko image used to build containers containing docker files - v1.8.1, uploaded April 5 2022
-  kaniko: gcr.io/kaniko-project/executor@sha256:b44b0744b450e731b5a5213058792cd8d3a6a14c119cf6b1f143704f22a7c650
+  # -- kaniko image used to build containers containing docker files - v1.24.0, uploaded May 23 2025
+  kaniko: gcr.io/kaniko-project/executor@sha256:4e7a52dd1f14872430652bb3b027405b8dfd17c4538751c620ac005741ef9698
   # -- git image
-  git: alpine/git:v2.32.0
+  git: alpine/git:v2.49.0
   # -- kustomize cli
-  kustomize: registry.k8s.io/kustomize/kustomize:v5.0.0  # https://kubectl.docs.kubernetes.io/installation/kustomize/docker/
+  kustomize: registry.k8s.io/kustomize/kustomize:v5.6.0  # https://kubectl.docs.kubernetes.io/installation/kustomize/docker/
   # -- kubectl cli
-  kubectl: bitnami/kubectl:1.22.10
+  kubectl: bitnami/kubectl:1.33.1
   # -- slack notifier
-  slack: cloudposse/slack-notifier:0.4.0
+  slack: cloudposse/slack-notifier:0.10.0
   # -- python image
   python: saritasallc/python3:0.4     # https://github.com/saritasa-nest/saritasa-devops-docker-images/tree/main/public/python/python3-alpine-boto
   # -- yamlfix image - format yaml files
@@ -28,7 +28,7 @@ images:
   # -- kubeval image - validate Kubernetes manifests
   kubeval: public.ecr.aws/saritasa/kubeval:0.16.1    # https://kubeval.instrumenta.dev/
   # -- sentry cli image - needs to prepare Sentry releases
-  sentry_cli: getsentry/sentry-cli:2.19.1    # https://github.com/getsentry/sentry-cli/
+  sentry_cli: getsentry/sentry-cli:2.46.0    # https://github.com/getsentry/sentry-cli/
 
 
 # ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
@@ -41,7 +41,7 @@ buildpacks:
   enabled: false
   # -- cnb (cloud native buildpacks) platform API to support
   # see more details [here](https://buildpacks.io/docs/reference/spec/platform-api/) and [here](https://github.com/buildpacks/spec/blob/main/platform.md)
-  cnbPlatformAPI: '0.4'
+  cnbPlatformAPI: '0.10'
   generate:
 # ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐
 # │ BUILDPACK: FRONTEND                                                                                                  │
@@ -169,7 +169,7 @@ buildpacks:
             privileged: true
 
         - name: fix-php-detection
-          image: docker.io/library/bash:5.1.8
+          image: docker.io/library/bash:5.2.37
           imagePullPolicy: IfNotPresent
           resources: {}
           workingDir: $(workspaces.app.path)
@@ -316,7 +316,7 @@ buildpacks:
       # @default -- see values.yaml for the default values of it
       buildTaskSteps:
         - name: git-fetch-tags
-          image: alpine/git:v2.32.0
+          image: alpine/git:v2.49.0
           imagePullPolicy: IfNotPresent
           resources: {}
           workingDir: $(workspaces.app.path)
@@ -361,7 +361,7 @@ buildpacks:
 
         - name: remove-dcproj-files
           workingDir: $(workspaces.app.path)
-          image: docker.io/library/bash:5.1.8
+          image: docker.io/library/bash:5.2.37
           imagePullPolicy: IfNotPresent
           resources: {}
           script: |

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -20,7 +20,7 @@ images:
   # -- kubectl cli
   kubectl: bitnami/kubectl:1.33.1
   # -- slack notifier
-  slack: cloudposse/slack-notifier:0.10.0
+  slack: cloudposse/slack-notifier:0.4.0
   # -- python image
   python: saritasallc/python3:0.4     # https://github.com/saritasa-nest/saritasa-devops-docker-images/tree/main/public/python/python3-alpine-boto
   # -- yamlfix image - format yaml files

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -321,6 +321,10 @@ buildpacks:
           resources: {}
           workingDir: $(workspaces.app.path)
           script: |
+            # Git 2.36+ added a new security feature that prevents Git from accessing repositories that are not owned by the user
+            # unless it's added as safe directory
+            # https://github.blog/open-source/git/highlights-from-git-2-36/#stricter-repository-ownership-checks
+            git config --global --add safe.directory /workspace/app
             git fetch --tags --unshallow
           securityContext:
             privileged: true

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -68,7 +68,7 @@ buildpacks:
           image: node:$(params.node_version)
           imagePullPolicy: IfNotPresent
           resources: {}
-          workingDir: $(resources.inputs.app.path)
+          workingDir: $(workspaces.app.path)
           script: |
             #!/usr/bin/env bash
             set -o pipefail
@@ -78,7 +78,7 @@ buildpacks:
             else
               echo "Installing node.js dependencies"
               # set cache
-              npm config set cache $(workspaces.source.path)/.npm --global
+              npm config set cache $(workspaces.app.path)/.npm --global
               npm ci
               if [[ $? -ne 0 ]]; then
                 echo "unable to install dependencies, exit_code: $?"
@@ -117,7 +117,7 @@ buildpacks:
       # - name: pre-deploy-hello-world
       #   image: node:22
       #   imagePullPolicy: IfNotPresent
-      #   workingDir: $(resources.inputs.app.path)
+      #   workingDir: $(workspaces.app.path)
       #   script: |
       #     #!/bin/bash
       #     echo "hello world"
@@ -151,7 +151,7 @@ buildpacks:
           image: node:$(params.node_version)
           imagePullPolicy: IfNotPresent
           resources: {}
-          workingDir: $(resources.inputs.app.path)
+          workingDir: $(workspaces.app.path)
           script: |
             #!/bin/bash
             set -e
@@ -159,7 +159,7 @@ buildpacks:
               echo "install node.js dependencies"
 
               # set cache
-              npm config set cache $(workspaces.source.path)/.npm --global
+              npm config set cache $(workspaces.app.path)/.npm --global
               npm ci
 
               npm run build:$(params.environment) || echo "unable to build $(params.environment)"
@@ -172,7 +172,7 @@ buildpacks:
           image: docker.io/library/bash:5.1.8
           imagePullPolicy: IfNotPresent
           resources: {}
-          workingDir: $(resources.inputs.app.path)
+          workingDir: $(workspaces.app.path)
           script: |
             #!/usr/bin/env bash
             # workaround to fix no PHP detection, when package.json presents
@@ -186,7 +186,7 @@ buildpacks:
       # - name: pre-deploy-hello-world
       #   image: node:22
       #   imagePullPolicy: IfNotPresent
-      #   workingDir: $(resources.inputs.app.path)
+      #   workingDir: $(workspaces.app.path)
       #   script: |
       #     #!/bin/bash
       #     echo "hello world"
@@ -215,7 +215,7 @@ buildpacks:
           image: node:$(params.node_version)
           imagePullPolicy: IfNotPresent
           resources: {}
-          workingDir: $(resources.inputs.app.path)
+          workingDir: $(workspaces.app.path)
           script: |
             #!/bin/bash
             set -e
@@ -223,7 +223,7 @@ buildpacks:
               echo "install node.js dependencies"
 
               # set cache
-              npm config set cache $(workspaces.source.path)/.npm --global
+              npm config set cache $(workspaces.app.path)/.npm --global
               npm ci
 
               npm run build:$(params.environment) || echo "unable to build $(params.environment)"
@@ -235,7 +235,7 @@ buildpacks:
           image: docker.io/saritasallc/python-ci:0.0.1
           imagePullPolicy: IfNotPresent
           resources: {}
-          workingDir: $(resources.inputs.app.path)
+          workingDir: $(workspaces.app.path)
           script: |
             #!/usr/bin/env bash
             set -eo pipefail
@@ -290,7 +290,7 @@ buildpacks:
       # - name: pre-deploy-hello-world
       #   image: node:22
       #   imagePullPolicy: IfNotPresent
-      #   workingDir: $(resources.inputs.app.path)
+      #   workingDir: $(workspaces.app.path)
       #   script: |
       #     #!/bin/bash
       #     echo "hello world"
@@ -319,7 +319,7 @@ buildpacks:
           image: alpine/git:v2.32.0
           imagePullPolicy: IfNotPresent
           resources: {}
-          workingDir: $(resources.inputs.app.path)
+          workingDir: $(workspaces.app.path)
           script: |
             git fetch --tags --unshallow
           securityContext:
@@ -327,7 +327,7 @@ buildpacks:
             runAsUser: 0
 
         - name: get-semantic-version
-          workingDir: $(resources.inputs.app.path)
+          workingDir: $(workspaces.app.path)
           image: gittools/gitversion:5.8.3-alpine.3.12-5.0-amd64
           imagePullPolicy: IfNotPresent
           resources: {}
@@ -356,26 +356,25 @@ buildpacks:
 
             /tools/dotnet-gitversion /updateprojectfiles
             git status
-            chown -R "$(params.user_id):$(params.group_id)" "$(workspaces.source.path)"
-            chown -R "$(params.user_id):$(params.group_id)" "$(resources.inputs.app.path)"
+            chown -R "$(params.user_id):$(params.group_id)" "$(workspaces.app.path)"
             echo "semantic version updated"
 
         - name: remove-dcproj-files
-          workingDir: $(resources.inputs.app.path)
+          workingDir: $(workspaces.app.path)
           image: docker.io/library/bash:5.1.8
           imagePullPolicy: IfNotPresent
           resources: {}
           script: |
             #!/usr/bin/env bash
             # clean `.dcproj` files related to local development docker .NET project
-            cd $(resources.inputs.app.path)
+            cd $(workspaces.app.path)
             find . -name '*.dcproj' -type f -delete
 
         - name: build-static
           image: node:$(params.node_version)
           imagePullPolicy: IfNotPresent
           resources: {}
-          workingDir: $(resources.inputs.app.path)
+          workingDir: $(workspaces.app.path)
           script: |
             #!/bin/bash
             set -Eeo pipefail
@@ -401,12 +400,11 @@ buildpacks:
               echo "install node.js dependencies"
 
               # set cache
-              npm config set cache $(workspaces.source.path)/.npm --global
+              npm config set cache $(workspaces.app.path)/.npm --global
               npm ci
 
               (npm run build:$(params.environment) && rm -rf node_modules && echo "remove node_modules dir") || (echo "unable to build $(params.environment)" && exit 1)
-              chown -R "$(params.user_id):$(params.group_id)" "$(workspaces.source.path)"
-              chown -R "$(params.user_id):$(params.group_id)" "$(resources.inputs.app.path)"
+              chown -R "$(params.user_id):$(params.group_id)" "$(workspaces.app.path)"
             } || echo "No package.json found"
 
             echo "done"
@@ -418,7 +416,7 @@ buildpacks:
       # - name: pre-deploy-hello-world
       #   image: node:22
       #   imagePullPolicy: IfNotPresent
-      #   workingDir: $(resources.inputs.app.path)
+      #   workingDir: $(workspaces.source.path)
       #   script: |
       #     #!/bin/bash
       #     echo "hello world"
@@ -444,7 +442,7 @@ buildpacks:
       # - name: pre-deploy-hello-world
       #   image: node:22
       #   imagePullPolicy: IfNotPresent
-      #   workingDir: $(resources.inputs.app.path)
+      #   workingDir: $(workspaces.app.path)
       #   script: |
       #     #!/bin/bash
       #     echo "hello world"
@@ -470,7 +468,7 @@ buildpacks:
       # - name: pre-deploy-hello-world
       #   image: node:22
       #   imagePullPolicy: IfNotPresent
-      #   workingDir: $(resources.inputs.app.path)
+      #   workingDir: $(workspaces.app.path)
       #   script: |
       #     #!/bin/bash
       #     echo "hello world"
@@ -496,7 +494,7 @@ buildpacks:
       # - name: pre-deploy-hello-world
       #   image: node:22
       #   imagePullPolicy: IfNotPresent
-      #   workingDir: $(resources.inputs.app.path)
+      #   workingDir: $(workspaces.app.path)
       #   script: |
       #     #!/bin/bash
       #     echo "hello world"
@@ -522,7 +520,7 @@ buildpacks:
       # - name: pre-deploy-hello-world
       #   image: node:22
       #   imagePullPolicy: IfNotPresent
-      #   workingDir: $(resources.inputs.app.path)
+      #   workingDir: $(workspaces.app.path)
       #   script: |
       #     #!/bin/bash
       #     echo "hello world"
@@ -536,7 +534,7 @@ kaniko:
   # - name: pre-deploy-hello-world
   #   image: node:22
   #   imagePullPolicy: IfNotPresent
-  #   workingDir: $(resources.inputs.app.path)
+  #   workingDir: $(workspaces.app.path)
   #   script: |
   #     #!/bin/bash
   #     echo "hello world"
@@ -561,6 +559,10 @@ podTemplate:
       operator: Equal
       value: 'true'
       effect: NoSchedule
+
+  # Ensure workspace PVC is group-writable by git-clone (runs as GID 65532)
+  securityContext:
+    fsGroup: 65532
 
 
 # ┌──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┐

--- a/charts/tekton/README.md
+++ b/charts/tekton/README.md
@@ -1,6 +1,7 @@
+
 # saritasa-tekton
 
-![Version: 2.0.0-dev.1](https://img.shields.io/badge/Version-2.0.0--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 2.0.0-dev.7](https://img.shields.io/badge/Version-2.0.0--dev.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 A Helm chart for tekton
 
@@ -17,7 +18,7 @@ A Helm chart for tekton
 | dashboard.ingress | object | `{}` |  |
 | dashboard.nodeSelector | object | `{}` |  |
 | dashboard.pipelineRuns.namespaces | list | `[]` |  |
-| dashboard.readOnly | bool | `true` |  |
+| dashboard.readOnly | bool | `false` |  |
 | dashboard.resources | object | `{}` |  |
 | dashboard.taskRuns.namespaces | list | `[]` |  |
 | dashboard.tolerations | list | `[]` |  |
@@ -26,9 +27,9 @@ A Helm chart for tekton
 | eventlistener.ingress.annotations."cert-manager.io/cluster-issuer" | string | `"letsencrypt-prod"` |  |
 | eventlistener.ingress.annotations."kubernetes.io/ingress.class" | string | `"nginx"` |  |
 | eventlistener.ingress.annotations."nginx.ingress.kubernetes.io/proxy-body-size" | string | `"100m"` |  |
-| eventlistener.ingress.enabled | bool | `false` |  |
+| eventlistener.ingress.enabled | bool | `true` |  |
 | eventlistener.ingress.hostname | string | `"tekton-webhook.site.com"` |  |
-| eventlistener.ingress.name | string | `"tekton-github-webhook"` |  |
+| eventlistener.ingress.name | string | `"github-webhook"` |  |
 | eventlistener.labelSelector.matchLabels.builder | string | `"tekton"` |  |
 | eventlistener.name | string | `"el"` |  |
 | eventlistener.namespace | string | `"ci"` |  |

--- a/charts/tekton/README.md
+++ b/charts/tekton/README.md
@@ -1,7 +1,7 @@
 
 # saritasa-tekton
 
-![Version: 2.0.0-dev.7](https://img.shields.io/badge/Version-2.0.0--dev.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
+![Version: 2.0.0](https://img.shields.io/badge/Version-2.0.0-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.0](https://img.shields.io/badge/AppVersion-1.1.0-informational?style=flat-square)
 
 A Helm chart for tekton
 


### PR DESCRIPTION
### Summary

Task: [SD-1271](https://saritasa.atlassian.net/browse/SD-1271)

- Update tekton-pipelines:
  - Removed resources blocks as they are deprecated
  - Add new git-clone task from tekton catalog
  - update all pipelines to use new versions and tasks



We previously used resources block to git clone the backend/frontend and also to clone the xx-kubernetes-repo.
I have added two new tasks to all pipelines

```
- git-clone-catalog
- git-clone-kubernetes

```
This run as the 1st step to replace the `resources`.



Charts were installed and tested in rma-staging and aaoa-ari-staging

Dotnet pipeline:

<details>

https://tekton.staging.dispatch.rmacompanies.com/#/pipelineruns
![image](https://github.com/user-attachments/assets/0fe894c9-c8c4-41f7-97ec-6bb26c51e50d)
![image](https://github.com/user-attachments/assets/17093d2d-672e-4e5f-8e3f-394c3dc6538c)

</details>

Kaniko and wordpress pipeline:

<details>

https://tekton.staging.tenantalert.com/#/pipelineruns
![image](https://github.com/user-attachments/assets/539ef7f3-43d1-4e3c-9d63-725aa9234f6d)
![image](https://github.com/user-attachments/assets/f7d28406-d186-41d6-8ec4-3d3bb10d981b)

</details>

Related PRs:
- https://github.com/saritasa-nest/rma-kubernetes-aws/pull/31
- https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/155
- https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/154


[SD-1271]: https://saritasa.atlassian.net/browse/SD-1271?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ