### PR TITLE
feat: remove shell code injection

### DIFF
--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.2
+version: 2.2.3-dev.1
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.2](https://img.shields.io/badge/Version-2.2.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.3-dev.1](https://img.shields.io/badge/Version-2.2.3--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/templates/common/tasks/slack-notification.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/slack-notification.yaml
@@ -71,6 +71,9 @@ spec:
     - name: notification
       image: {{ .Values.images.slack | default "cloudposse/slack-notifier:latest"}}
       imagePullPolicy: {{ .Values.imagePullPolicy }}
+      env:
+        - name: head_commit_message
+          value: $(params.head_commit_message)
       script: |
         #!/bin/sh
 
@@ -88,7 +91,6 @@ spec:
           color="good"
           thumb_url="$(params.pusher_avatar)"
           text_status="The latest changes to $(params.environment) have been deployed successfully"
-
         else
           color="danger"
           thumb_url="$SLACK_FAILURE_ICON_URL"
@@ -105,16 +107,14 @@ spec:
 
         # Preparing jira links
         # We are using grep as ash doesn't support regex test
-        jira_task=$(echo "$(params.head_commit_message)" | grep -oE '[A-Z0-9]+-[0-9]+' | head -n 1 )
+        jira_task=$(echo "$head_commit_message" | grep -oE '[A-Z0-9]+-[0-9]+' | head -n 1 )
         if [ "$jira_task" != "" ];
         then
           echo "Found $jira_task jira task, preparing link"
-          head_commit_message=$(echo "$(params.head_commit_message)" | sed "s|$jira_task|\<https://saritasa.atlassian.net/browse/$jira_task/\|$jira_task\>|")
+          head_commit_message=$(echo "$head_commit_message" | sed "s|$jira_task|\<https://saritasa.atlassian.net/browse/$jira_task/\|$jira_task\>|")
         else
           echo "No jira task found";
-          head_commit_message="$(params.head_commit_message)"
         fi
-
 
         slack-notifier \
         -user_name "Tekton" \


### PR DESCRIPTION
### Summary

Task: [SD-1349](https://saritasa.atlassian.net/browse/SD-1349)

Changes:
- remove shell code injection from `slack-notification` task in `tekton-pipelines` chart

### Problem

An excerpt from Tekton's documentation:
> The mechanism of variable substitution is quite simple - string replacement is performed by the Tekton Controller when a TaskRun is executed.

So, `... echo "$(params.head_commit_message)" ...` turned into:

```
... echo "Trigger build

And perform some remote code execution:
`uname -a`" ...
```

<img width="388" height="128" alt="code injection in action" src="https://github.com/user-attachments/assets/0fcd4649-0d80-4ea2-86f0-f936cb467736" />

### Solution

First I tried adding single quotes (i.e. `'$(params.head_commit_message)'`). It worked, but only for some messages. The crux of the problem is that Tekton injects the parameter in the script without doing any preprocessing / quoting. One could try using heredoc with a cryptic EOF marker, but that's just security through obscurity.

Unfortunately, there is currently no way to get the value of a parameter, say, through a file, avoiding injecting user-controlled text into the script:
- https://github.com/tektoncd/community/pull/208#issuecomment-720603817
- https://github.com/tektoncd/pipeline/issues/3458
- https://github.com/tektoncd/triggers/issues/675#issuecomment-1064254012

There is a proposal ([TEP-0146](https://github.com/tektoncd/community/blob/main/teps/0146-parameters-in-script.md)) addressing this issue, but it has been in ["proposed" status](https://github.com/tektoncd/community/blob/32f00b664d3954d0f9c0c375d700c8aa5371381d/teps/0146-parameters-in-script.md?plain=1#L2) for almost two years.

#### Workaround

So for now, I have implemented passing the message through an environment variable for the step. At the moment this is the safest solution.

### Test results

1. Switched to the updated chart revision for `tekton-pipelines-experiments` app:
<img width="589" height="197" alt="synced the chart" src="https://github.com/user-attachments/assets/4c24e195-e87d-4de3-a806-da9e6ec6ed14" />

2. Made a commit attempting code injection:
<img width="269" height="160" alt="made a commit" src="https://github.com/user-attachments/assets/3681876f-8097-44c3-9c24-f4d31762fd17" />

3. The build succeeded:

<img width="522" height="300" alt="the build succeeded" src="https://github.com/user-attachments/assets/92d69b19-d57c-41f0-8495-6583429f6dc5" />

4. The notification didn't contain the command output, only the text itself:

<img width="305" height="214" src="https://github.com/user-attachments/assets/5512f646-99fe-4a84-937c-9975248b9171" />