### PR TITLE
feat: add set-env-vars step for python buildpack SD-1342

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2025-08-02
+
+[prod]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/161)
+- Add step `set-env-vars` to set environment variables for buildpack
+
 ## 2025-08-01
 
 [prod]

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.3-dev.1
+version: 2.2.4-dev.nadya.25
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.4-dev.nadya.25
+version: 2.2.4-dev.nadya.26
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.4-dev.nadya.25](https://img.shields.io/badge/Version-2.2.4--dev.nadya.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.4-dev.nadya.26](https://img.shields.io/badge/Version-2.2.4--dev.nadya.26-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.3-dev.1](https://img.shields.io/badge/Version-2.2.3--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.4-dev.nadya.25](https://img.shields.io/badge/Version-2.2.4--dev.nadya.25-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
@@ -50,7 +50,9 @@ spec:
 
     - name: buildpack_env_vars
       type: string
-      description: environment variables that should be passed to buildpack
+      description: |-
+        environment variables that should be passed to buildpack
+        expected string format: 'BP_POETRY_INSTALL_ONLY=main,dev;BP_OCI_VENDOR=saritasa'
       default: ""
 
     - name: source_subpath

--- a/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
@@ -48,6 +48,11 @@ spec:
       type: string
       description: reference to a run image to use
 
+    - name: buildpack_env_vars
+      type: string
+      description: environment variables that should be passed to buildpack
+      default: ""
+
     - name: source_subpath
       type: string
       description: a subpath within the `source` input where the source to build is located.
@@ -149,6 +154,8 @@ spec:
           value: "$(params.buildpack_builder_image)"
         - name: run_image
           value: "$(params.buildpack_runner_image)"
+        - name: buildpack_env_vars
+          value: "$(params.buildpack_env_vars)"
         - name: docker_registry
           value: $(params.docker_registry)
         - name: cache

--- a/charts/tekton-pipelines/templates/buildpacks/tasks/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/tasks/_buildpack.yaml
@@ -31,7 +31,9 @@ spec:
 
     - name: buildpack_env_vars
       type: string
-      description: environment variables that should be passed to buildpack
+      description: |-
+        environment variables that should be passed to buildpack
+        expected string format: 'BP_POETRY_INSTALL_ONLY=main,dev;BP_OCI_VENDOR=saritasa'
       default: ""
 
     - name: docker_registry

--- a/charts/tekton-pipelines/templates/buildpacks/tasks/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/tasks/_buildpack.yaml
@@ -29,6 +29,11 @@ spec:
       description: reference to a run image to use
       default: ""
 
+    - name: buildpack_env_vars
+      type: string
+      description: environment variables that should be passed to buildpack
+      default: ""
+
     - name: docker_registry
       type: string
       description: private docker registry address

--- a/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
@@ -38,6 +38,10 @@ spec:
     - name: buildpack_runner_image
       description: reference to a run image to use
 
+    - name: buildpack_env_vars
+      description: environment variables that should be passed to buildpack
+      default: ""
+
     - name: source_subpath
       description: a subpath within the `source` input where the source to build is located.
       default: ""
@@ -100,6 +104,8 @@ spec:
           value: "$(tt.params.buildpack_builder_image)"
         - name: buildpack_runner_image
           value: "$(tt.params.buildpack_runner_image)"
+        - name: buildpack_env_vars
+          value: "$(tt.params.buildpack_env_vars)"
         - name: source_subpath
           value: "$(tt.params.source_subpath)"
         - name: repository_submodules

--- a/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
@@ -39,7 +39,9 @@ spec:
       description: reference to a run image to use
 
     - name: buildpack_env_vars
-      description: environment variables that should be passed to buildpack
+      description: |-
+        environment variables that should be passed to buildpack
+        expected string format: 'BP_POETRY_INSTALL_ONLY=main,dev;BP_OCI_VENDOR=saritasa'
       default: ""
 
     - name: source_subpath

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -270,6 +270,40 @@ buildpacks:
               echo "Creating ${env_dir}/${key} with value: ${value}"
               echo "$value" > "${env_dir}/${key}"
             done
+        - name: copy-requirements
+          image: docker.io/saritasallc/python-ci:0.0.1
+          imagePullPolicy: IfNotPresent
+          resources: {}
+          workingDir: $(workspaces.app.path)
+          script: |
+            #!/usr/bin/env bash
+            set -eo pipefail
+
+            if [[ -f uv.lock ]]; then
+              if [[ ! $(command -v uv) ]]; then
+                echo "uv is not installed or not in PATH. Halting execution."
+                exit 1
+              fi
+              echo "'uv.lock' is found, preparing requirements.txt"
+              if [[ "$(params.environment)" == "dev" ]]; then
+                echo "Export with 'dev' targets dependencies"
+                uv export --format requirements-txt --output-file requirements.txt
+                exit 0
+              fi
+              uv export --format requirements-txt --no-dev --output-file requirements.txt
+              exit 0
+            fi
+
+            if ls requirements/$(params.environment)*.txt >/dev/null 2>&1; then
+              echo "'requirements' folder is found, preparing requirements.txt"
+              cp requirements/$(params.environment)*.txt requirements.txt
+              exit 0
+            fi
+
+            if [[ -f requirements.txt ]]; then
+              echo "'requirements.txt' found"
+              exit 0
+            fi
       # -- steps to run in the `pre-deploy` task prior to ArgoCD sync command
       # can be useful to prepare different backups and tests before real deploy
       preDeployTaskSteps: []

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -231,59 +231,45 @@ buildpacks:
             } || echo "No package.json found"
           securityContext:
             privileged: true
-        - name: copy-requirements
-          image: docker.io/saritasallc/python-ci:0.0.1
+        - name: set-env-vars
+          image: saritasallc/tekton:1.0.8
           imagePullPolicy: IfNotPresent
           resources: {}
           workingDir: $(workspaces.app.path)
+          env:
+            - name: environment
+              value: $(params.environment)
+            - name: platform_dir
+              value: $(params.platform_dir)
+            - name: source_path
+              value: $(workspaces.app.path)
           script: |
             #!/usr/bin/env bash
             set -eo pipefail
+            buildpack_env_vars="$(params.buildpack_env_vars)"
+            env_dir="${source_path}/${platform_dir}/env"
+            mkdir -p ${env_dir}
 
-            if [[ -f poetry.lock ]]; then
-              if [[ ! $(command -v poetry) ]]; then
-                echo "poetry is not installed or not in PATH. Halting execution."
-                exit 1
+            # Add `BP_POETRY_INSTALL_ONLY` variable that specifies
+            # which package groups should be installed during build
+            if ! echo "${buildpack_env_vars}" | grep -q "BP_POETRY_INSTALL_ONLY"; then
+              echo "Adding BP_POETRY_INSTALL_ONLY environment variable"
+              bp_poetry_install_only="main"
+              if [[ "${environment}" == "dev" ]]; then
+                bp_poetry_install_only="${bp_poetry_install_only},dev"
               fi
-              echo "'poetry.lock' is found, preparing requirements.txt"
-              TARGET="main"
-              if [[ "$(params.environment)" == "dev" ]]; then
-                TARGET="${TARGET},dev"
-              fi
-              echo "Export '${TARGET}' targets dependencies"
-              poetry export --without-hashes --with ${TARGET} --output requirements.txt
-              exit 0
+              buildpack_env_vars="BP_POETRY_INSTALL_ONLY=${bp_poetry_install_only};${buildpack_env_vars}"
+              echo "Added BP_POETRY_INSTALL_ONLY=${bp_poetry_install_only}"
             fi
 
-            if [[ -f uv.lock ]]; then
-              if [[ ! $(command -v uv) ]]; then
-                echo "uv is not installed or not in PATH. Halting execution."
-                exit 1
-              fi
-              echo "'uv.lock' is found, preparing requirements.txt"
-              if [[ "$(params.environment)" == "dev" ]]; then
-                echo "Export with 'dev' targets dependencies"
-                uv export --format requirements-txt --output-file requirements.txt
-                exit 0
-              fi
-              uv export --format requirements-txt --no-dev --output-file requirements.txt
-              exit 0
-            fi
-
-            if ls requirements/$(params.environment)*.txt >/dev/null 2>&1; then
-              echo "'requirements' folder is found, preparing requirements.txt"
-              cp requirements/$(params.environment)*.txt requirements.txt
-              exit 0
-            fi
-
-            if [[ -f requirements.txt ]]; then
-              echo "'requirements.txt' found"
-              exit 0
-            fi
-
-            # otherwise raise error, because no requirements were found
-            echo "requirements.txt is not found! Halting execution."
-            exit 1
+            # parse environment variables and add them to the platform directory
+            IFS=';' read -ra env_vars <<< "${buildpack_env_vars}"
+            for env_var in "${env_vars[@]}"; do
+              key=$(echo ${env_var} | cut -d'=' -f1)
+              value=$(echo ${env_var} | cut -d'=' -f2-)
+              echo "Creating ${env_dir}/${key} with value: ${value}"
+              echo "$value" > "${env_dir}/${key}"
+            done
       # -- steps to run in the `pre-deploy` task prior to ArgoCD sync command
       # can be useful to prepare different backups and tests before real deploy
       preDeployTaskSteps: []


### PR DESCRIPTION
### Summary

Task: [SD-1342](https://saritasa.atlassian.net/browse/SD-1342)

- added `set-env-vars` step to `buildpack-django` pipeline to set environment variables for buildpack-django
- removed `requirements.txt` creation with `poetry.lock` from `copy-requirements` step since `requirements.txt` file is not needed when specifying groups of packages to install via `BP_POETRY_INSTALL_ONLY` variable

[test pipelinerun](https://tekton.saritasa.rocks/#/namespaces/ci-experiments/pipelineruns/saritasa-ci-experiments-django-backend-dev-build-pipeline-qphrv?pipelineTask=buildpack-django&step=build)

variable set:

<img width="3132" height="1037" alt="image" src="https://github.com/user-attachments/assets/2c1607d5-8162-466c-a149-73e5f1ff4f3d" />

variable used in buildpack (default value is `main`):

<img width="2612" height="293" alt="image" src="https://github.com/user-attachments/assets/920a36f2-edfc-4e5e-a901-7843912a4aec" />

passing additional environment variables:

```bash
triggerBinding:
  - name: buildpack_env_vars
    value: 'BP_POETRY_INSTALL_ONLY=main,dev;BP_OCI_VENDOR=saritasa'
```

<!--
Description should contain link to valid task in Jira, short description of the implemented feature.
Please ensure that actions passed.
-->


[SD-1342]: https://saritasa.atlassian.net/browse/SD-1342?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ