### PR TITLE
feat: add git-clone step to sentry SD-373

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 [dev]
 
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/164)
+- Add `git-clone-sentry` task to dotnet pipelines (fixes error dotnet sentry release)
+
 - [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/163)
 - Add when condition `buildpack_env_vars=DISABLE_GIT_VERSION` for `git-fetch-tags` step in Dotnet pipeline
 

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.5-dev.2
+version: 2.2.6-dev.1
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.6-dev.5
+version: 2.2.6-dev.6
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.6-dev.3
+version: 2.2.6-dev.4
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.6-dev.1
+version: 2.2.6-dev.2
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.6-dev.7
+version: 2.2.6
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.6-dev.2
+version: 2.2.6-dev.3
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.6-dev.4
+version: 2.2.6-dev.5
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.6-dev.4](https://img.shields.io/badge/Version-2.2.6--dev.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.6-dev.5](https://img.shields.io/badge/Version-2.2.6--dev.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.5-dev.2](https://img.shields.io/badge/Version-2.2.5--dev.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.6-dev.1](https://img.shields.io/badge/Version-2.2.6--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.6-dev.2](https://img.shields.io/badge/Version-2.2.6--dev.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.6-dev.4](https://img.shields.io/badge/Version-2.2.6--dev.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,8 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-<<<<<<< HEAD
-![Version: 2.2.6-dev.7](https://img.shields.io/badge/Version-2.2.6--dev.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.6](https://img.shields.io/badge/Version-2.2.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.6-dev.1](https://img.shields.io/badge/Version-2.2.6--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.6-dev.2](https://img.shields.io/badge/Version-2.2.6--dev.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.6-dev.5](https://img.shields.io/badge/Version-2.2.6--dev.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.6-dev.6](https://img.shields.io/badge/Version-2.2.6--dev.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 
@@ -275,7 +275,7 @@ After configuring these values, you will have an extra `sentry-release` step aft
 | images.sentry_cli | string | `"getsentry/sentry-cli:2.46.0"` | sentry cli image - needs to prepare Sentry releases |
 | images.slack | string | `"cloudposse/slack-notifier:0.4.0"` | slack notifier |
 | images.yamlfix | string | `"public.ecr.aws/saritasa/yamlfix:1.8.1"` | yamlfix image - format yaml files |
-| kaniko.enabled | bool | `false` | should we enable the kaniko pipeline |
+| kaniko.enabled | bool | `true` | should we enable the kaniko pipeline |
 | kaniko.preDeployTaskSteps | list | `[]` | steps to run in the `pre-deploy` task prior to ArgoCD sync command can be useful to prepare different backups and tests before real deploy |
 | podTemplate | object | see values.yaml | default configuration to be added into each pod created by tekton engine we want to plave them in a specific node with added tolerations/taints. |
 | podTemplate.nodeSelector | object | `{"ci":"true"}` | node selector for pods spawned by tekton |
@@ -283,7 +283,7 @@ After configuring these values, you will have an extra `sentry-release` step aft
 | saritasa-tekton.enabled | bool | `false` | should we configure dependency chart here. |
 | sentry.authTokenSecret | string | `"sentry-auth-token"` |  |
 | sentry.authTokenSecretKey | string | `"auth-token"` |  |
-| sentry.enabled | bool | `false` |  |
+| sentry.enabled | bool | `true` |  |
 | sentry.org | string | `"saritasa"` |  |
 | sentry.url | string | `"https://sentry.saritasa.rocks/"` |  |
 | wordpress.enabled | bool | `false` | should we enable the wordpress pipeline |

--- a/charts/tekton-pipelines/templates/_snippets.tpl
+++ b/charts/tekton-pipelines/templates/_snippets.tpl
@@ -238,12 +238,12 @@ finally:
     - name: sourcemaps_dir
       value: "$(params.sourcemaps_dir)"
     - name: subdirectory
-      value: sentry
+      value: {{ default "." .subdirectory | quote }}
   workspaces:
     - name: source
       workspace: source
   runAfter:
-    - git-clone-sentry
+    - {{ if eq .pipeline.name "buildpack-dotnet-build-pipeline" }} git-clone-sentry {{ else }} deploy {{ end }}
 {{- end }}
 
 # ┌──────────────────────────────────────────────────────────────────────────────┐

--- a/charts/tekton-pipelines/templates/_snippets.tpl
+++ b/charts/tekton-pipelines/templates/_snippets.tpl
@@ -243,7 +243,7 @@ finally:
     - name: source
       workspace: source
   runAfter:
-    - {{ if eq .pipeline.name "buildpack-dotnet-build-pipeline" }} git-clone-sentry {{ else }} deploy {{ end }}
+    - {{ if eq (.pipeline).name "buildpack-dotnet-build-pipeline" }} git-clone-sentry {{ else }} deploy {{ end }}
 {{- end }}
 
 # ┌──────────────────────────────────────────────────────────────────────────────┐

--- a/charts/tekton-pipelines/templates/_snippets.tpl
+++ b/charts/tekton-pipelines/templates/_snippets.tpl
@@ -237,11 +237,13 @@ finally:
       value: "$(params.sentry_project_name)"
     - name: sourcemaps_dir
       value: "$(params.sourcemaps_dir)"
+    - name: subdirectory
+      value: sentry
   workspaces:
     - name: source
       workspace: source
   runAfter:
-    - deploy
+    - git-clone-sentry
 {{- end }}
 
 # ┌──────────────────────────────────────────────────────────────────────────────┐

--- a/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
@@ -247,6 +247,7 @@ spec:
 
   {{ if .sentry.enabled }}
 
+    {{ if eq .pipeline.name "buildpack-dotnet-build-pipeline" }}
     # Dotnet tasks remove the source code from the workspace, so we need to clone it again
     - name: git-clone-sentry
       taskRef:
@@ -264,7 +265,12 @@ spec:
       runAfter:
         - deploy
 
+    {{ include "pipeline.sentryRelease" (merge (dict "subdirectory" "sentry") .) | nindent 4 }}
+
+    {{- end }}
+
     {{ include "pipeline.sentryRelease" . | nindent 4 }}
+
   {{ end }}
 
   {{ include "pipeline.postDeploy" (dict "name" (printf "%s-post-deploy" .pipeline.name) "sentry_enabled" .sentry.enabled) | nindent 4 }}

--- a/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
@@ -266,11 +266,9 @@ spec:
         - deploy
 
     {{ include "pipeline.sentryRelease" (merge (dict "subdirectory" "sentry") .) | nindent 4 }}
-
-    {{- end }}
-
+    {{- else }}
     {{ include "pipeline.sentryRelease" . | nindent 4 }}
-
+    {{- end }}
   {{ end }}
 
   {{ include "pipeline.postDeploy" (dict "name" (printf "%s-post-deploy" .pipeline.name) "sentry_enabled" .sentry.enabled) | nindent 4 }}

--- a/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
@@ -247,7 +247,6 @@ spec:
 
   {{ if .sentry.enabled }}
 
-    {{ if eq .pipeline.name "buildpack-dotnet-build-pipeline" }}
     # Dotnet tasks remove the source code from the workspace, so we need to clone it again
     - name: git-clone-sentry
       taskRef:
@@ -260,9 +259,10 @@ spec:
         value: $(params.repository_ssh_url)
       - name: revision
         value: $(params.branch)
+      - name: subdirectory
+        value: sentry
       runAfter:
         - deploy
-    {{ end }}
 
     {{ include "pipeline.sentryRelease" . | nindent 4 }}
   {{ end }}

--- a/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
@@ -246,6 +246,22 @@ spec:
         - {{ if (.pipeline).preDeployTaskSteps }} pre-deploy {{ else }} kustomize {{ end }}
 
   {{ if .sentry.enabled }}
+
+    {{ if eq .pipeline.name "buildpack-dotnet-build-pipeline" }}
+    # Dotnet tasks remove the source code from the workspace, so we need to clone it again
+    - name: git-clone-sentry
+      taskRef:
+        name: git-clone
+      workspaces:
+      - name: output
+        workspace: source
+      params:
+      - name: url
+        value: $(params.repository_ssh_url)
+      - name: revision
+        value: $(params.branch)
+    {{ end }}
+
     {{ include "pipeline.sentryRelease" . | nindent 4 }}
   {{ end }}
 

--- a/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
@@ -260,6 +260,8 @@ spec:
         value: $(params.repository_ssh_url)
       - name: revision
         value: $(params.branch)
+      runAfter:
+        - deploy
     {{ end }}
 
     {{ include "pipeline.sentryRelease" . | nindent 4 }}

--- a/charts/tekton-pipelines/templates/common/tasks/sentry-release.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/sentry-release.yaml
@@ -27,6 +27,11 @@ spec:
       description: name of the dir where frontend sourcemaps would be stored in workspace
       default: "sourcemaps"
 
+    - name: subdirectory
+      type: string
+      description: Working dir subdirectory
+      default: ""
+
   stepTemplate:
     env:
       - name: SENTRY_AUTH_TOKEN
@@ -49,7 +54,7 @@ spec:
         runAsNonRoot: false
         privileged: false
         allowPrivilegeEscalation: false
-      workingDir: $(workspaces.source.path)
+      workingDir: $(workspaces.source.path)/$(params.subdirectory)
       script: |
         #!/usr/bin/env sh
         set -eu
@@ -73,7 +78,7 @@ spec:
         runAsNonRoot: false
         privileged: false
         allowPrivilegeEscalation: false
-      workingDir: $(workspaces.source.path)
+      workingDir: $(workspaces.source.path)/$(params.subdirectory)
       script: |
         #!/usr/bin/env sh
         set +x
@@ -124,7 +129,7 @@ spec:
         runAsNonRoot: false
         privileged: false
         allowPrivilegeEscalation: false
-      workingDir: $(workspaces.source.path)
+      workingDir: $(workspaces.source.path)/$(params.subdirectory)
       script: |
         #!/usr/bin/env sh
         set -eu

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -559,7 +559,7 @@ buildpacks:
 
 kaniko:
   # -- should we enable the kaniko pipeline
-  enabled: false
+  enabled: true
   # -- steps to run in the `pre-deploy` task prior to ArgoCD sync command
   # can be useful to prepare different backups and tests before real deploy
   preDeployTaskSteps: []
@@ -611,7 +611,7 @@ saritasa-tekton:
 # │                                                                                                                      │
 # └──────────────────────────────────────────────────────────────────────────────────────────────────────────────────────┘
 sentry:
-  enabled: false
+  enabled: true
   authTokenSecret: "sentry-auth-token"  # auth token to connect to Sentry API
   authTokenSecretKey: "auth-token"
   org: "saritasa"


### PR DESCRIPTION
### Summary

Task: [SD-373](https://saritasa.atlassian.net/browse/SD-373)

- add new git-clone-sentry step when pipeline is dotnet

Problem:
Dotnet pipelines were failing because the sentry step always resulted in failure:

Example: https://tekton.saritasa.rocks/#/namespaces/ci/pipelineruns/renewaire-backend-dev-build-pipeline-run-pw4kr?pipelineTask=sentry-release&step=release
<img width="1320" height="976" alt="image" src="https://github.com/user-attachments/assets/9aaacfde-50c2-4af7-b592-7276d4285cb6" />

The problem is that dotnet buildpack deletes the source code 
<img width="1278" height="788" alt="image" src="https://github.com/user-attachments/assets/7290185e-630f-4e04-9320-6a67c0953854" />
and then sentry can't evaluate the `VERSION` because there isn't a .git folder anymore.

Fix:
I have a conditional step git-clone-sentry that will only execute when the pipeline is dotnet
For all other buildpacks/kaniko the workflow is not modified



<details>
 <summary>Proofs:</summary>

New step clones into sentry/ folder
https://tekton.saritasa.rocks/#/namespaces/ci/pipelineruns/renewaire-backend-dev-build-pipeline-run-26cwn-r-qrxhn?pipelineTask=slack-notification&step=notification
<img width="1852" height="1192" alt="image" src="https://github.com/user-attachments/assets/84f1312b-9487-4d77-8729-045b1baee2e5" />

And then sentry task uses this /workspace/source/sentry as the workingDir

Other pipelines don't have this step. Continue to work as before
<img width="972" height="1332" alt="image" src="https://github.com/user-attachments/assets/45af59d3-996c-46ea-a357-75f808a32063" />

</details>

[SD-373]: https://saritasa.atlassian.net/browse/SD-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ