### PR TITLE
feat: allow insecure WordPess images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2025-10-06
+
+[dev]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/176)
+- Specify allowInsecureImages for WordPress application to allow bitnamilegacy images
+
 ## 2025-10-01
 
 [dev]

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: "v0.29.2"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.5-dev.1
+version: 2.1.5
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: "v0.29.2"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.4
+version: 2.1.5-dev.1
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 2.1.5-dev.1](https://img.shields.io/badge/Version-2.1.5--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.2](https://img.shields.io/badge/AppVersion-v0.29.2-informational?style=flat-square)
+![Version: 2.1.5](https://img.shields.io/badge/Version-2.1.5-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.2](https://img.shields.io/badge/AppVersion-v0.29.2-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 2.1.4](https://img.shields.io/badge/Version-2.1.4-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.2](https://img.shields.io/badge/AppVersion-v0.29.2-informational?style=flat-square)
+![Version: 2.1.5-dev.1](https://img.shields.io/badge/Version-2.1.5--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.2](https://img.shields.io/badge/AppVersion-v0.29.2-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-apps/templates/wordpress/argocd_applications.yaml
+++ b/charts/tekton-apps/templates/wordpress/argocd_applications.yaml
@@ -43,6 +43,10 @@ spec:
     chart: wordpress
     helm:
       values: |
+        global:
+          security:
+            allowInsecureImages: true
+
         image:
           repository: bitnamilegacy/wordpress
           tag: {{ (.image).tag | default "6.1.1" }}


### PR DESCRIPTION
### Summary

Task: [SD-373](https://saritasa.atlassian.net/browse/SD-373)

Changes:
- specify `global.security.allowInsecureImages` for WordPress application to allow `bitnamilegacy` images

Without that option, I was getting this error on sync in Rocks:

<img width="1427" height="683" src="https://github.com/user-attachments/assets/5ccfc0cb-1a3a-4f21-ba70-2538eaa5cc72" />

[SD-373]: https://saritasa.atlassian.net/browse/SD-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ