### PR TITLE
feat: add terminate concurrent runs task

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,9 @@
 
 ## 2026-03-16
 
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/189)
+- Add terminate-concurrent-runs task
+
 - [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/188)
 - Fix yamlfix step in tekton-pipelines
 

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: "v0.29.2"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.9
+version: 2.1.10-dev.1
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-apps/Chart.yaml
+++ b/charts/tekton-apps/Chart.yaml
@@ -12,7 +12,7 @@ appVersion: "v0.29.2"
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.1.10-dev.1
+version: 2.1.10
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 2.1.9](https://img.shields.io/badge/Version-2.1.9-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.2](https://img.shields.io/badge/AppVersion-v0.29.2-informational?style=flat-square)
+![Version: 2.1.10-dev.1](https://img.shields.io/badge/Version-2.1.10--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.2](https://img.shields.io/badge/AppVersion-v0.29.2-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-apps/README.md
+++ b/charts/tekton-apps/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-apps
 
 ## `chart.version`
 
-![Version: 2.1.10-dev.1](https://img.shields.io/badge/Version-2.1.10--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.2](https://img.shields.io/badge/AppVersion-v0.29.2-informational?style=flat-square)
+![Version: 2.1.10](https://img.shields.io/badge/Version-2.1.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: v0.29.2](https://img.shields.io/badge/AppVersion-v0.29.2-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-apps/templates/roles.yaml
+++ b/charts/tekton-apps/templates/roles.yaml
@@ -25,10 +25,10 @@ rules:
     verbs:      ["get", "list", "watch"]
   - apiGroups:  ["tekton.dev"]
     resources:  ["pipelineruns"]
-    verbs:      ["get", "list", "create"]
+    verbs:      ["get", "list", "create", "delete"]
   - apiGroups:  ["tekton.dev"]
     resources:  ["taskruns"]
-    verbs:      ["get", "list", "watch"]
+    verbs:      ["get", "list", "watch", "create", "delete"]
 
 ---
 kind: RoleBinding

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.18
+version: 2.2.19-dev.1
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.19-dev.12
+version: 2.2.19-dev.13
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.19-dev.8
+version: 2.2.19-dev.10
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.19-dev.11
+version: 2.2.19-dev.12
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.19-dev.10
+version: 2.2.19-dev.11
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.19-dev.1
+version: 2.2.19-dev.8
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.19-dev.13
+version: 2.2.19
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.19-dev.1](https://img.shields.io/badge/Version-2.2.19--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.19-dev.8](https://img.shields.io/badge/Version-2.2.19--dev.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.19-dev.11](https://img.shields.io/badge/Version-2.2.19--dev.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.19-dev.12](https://img.shields.io/badge/Version-2.2.19--dev.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.19-dev.10](https://img.shields.io/badge/Version-2.2.19--dev.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.19-dev.11](https://img.shields.io/badge/Version-2.2.19--dev.11-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.18](https://img.shields.io/badge/Version-2.2.18-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.19-dev.1](https://img.shields.io/badge/Version-2.2.19--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.19-dev.13](https://img.shields.io/badge/Version-2.2.19--dev.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.19](https://img.shields.io/badge/Version-2.2.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.19-dev.12](https://img.shields.io/badge/Version-2.2.19--dev.12-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.19-dev.13](https://img.shields.io/badge/Version-2.2.19--dev.13-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.19-dev.8](https://img.shields.io/badge/Version-2.2.19--dev.8-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.19-dev.10](https://img.shields.io/badge/Version-2.2.19--dev.10-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/templates/_helpers.tpl
+++ b/charts/tekton-pipelines/templates/_helpers.tpl
@@ -60,3 +60,16 @@ Create the name of the service account to use
 {{- default "default" .Values.serviceAccount.name }}
 {{- end }}
 {{- end }}
+
+{{/*
+Common labels
+*/}}
+{{- define "task.labels" -}}
+helm.sh/chart: {{ include "task.chart" . }}
+app.kubernetes.io/version: {{ .Chart.Version }}
+app.kubernetes.io/managed-by: {{ .Release.Service }}
+app.kubernetes.io/part-of: {{ .Release.Name }}
+{{- with .Values.extraLabels }}
+{{ . | toYaml }}
+{{- end }}
+{{- end }}

--- a/charts/tekton-pipelines/templates/_helpers.tpl
+++ b/charts/tekton-pipelines/templates/_helpers.tpl
@@ -62,6 +62,13 @@ Create the name of the service account to use
 {{- end }}
 
 {{/*
+Create chart name and version as used by the chart label.
+*/}}
+{{- define "task.chart" -}}
+{{- printf "%s-%s" .Chart.Name .Chart.Version | replace "+" "_" | trunc 63 | trimSuffix "-" }}
+{{- end }}
+
+{{/*
 Common labels
 */}}
 {{- define "task.labels" -}}

--- a/charts/tekton-pipelines/templates/buildkit/pipeline.yaml
+++ b/charts/tekton-pipelines/templates/buildkit/pipeline.yaml
@@ -55,10 +55,37 @@ spec:
       type: string
       description: git repository ssh url for kubernetes manifests repo
 
+    - name: terminate-concurrent-runs
+      description: whether to terminate concurrent runs of the same pipeline
+      default: ""
+
+    - name: commit_timestamp
+      description: Timestamp of the commit that triggered the current pipeline.
+      type: string
+      default: ""
+
   workspaces:
     - name: source
 
   tasks:
+    - name: terminate-concurrent-runs
+      when:
+        - input: $(params.terminate-concurrent-runs)
+          operator: in
+          values:
+            - 'true'
+      taskRef:
+        name: terminate-concurrent-runs
+      params:
+        - name: commit_timestamp
+          value: $(params.commit_timestamp)
+        - name: namespace
+          value: $(params.namespace)
+        - name: pipeline_name
+          value: $(context.pipeline.name)
+        - name: pipelinerun_name
+          value: $(context.pipelineRun.name)
+
     - name: git-clone
       taskRef:
         name: git-clone

--- a/charts/tekton-pipelines/templates/buildkit/pipeline.yaml
+++ b/charts/tekton-pipelines/templates/buildkit/pipeline.yaml
@@ -64,11 +64,6 @@ spec:
       type: string
       default: ""
 
-    - name: app
-      type: string
-      description: name of the application
-      default: ""
-
   workspaces:
     - name: source
 
@@ -90,7 +85,7 @@ spec:
           value: $(context.pipeline.name)
         - name: pipelinerun_name
           value: $(context.pipelineRun.name)
-        - name: app
+        - name: application
           value: "$(params.application)"
 
     - name: git-clone

--- a/charts/tekton-pipelines/templates/buildkit/pipeline.yaml
+++ b/charts/tekton-pipelines/templates/buildkit/pipeline.yaml
@@ -64,6 +64,11 @@ spec:
       type: string
       default: ""
 
+    - name: app
+      type: string
+      description: name of the application
+      default: ""
+
   workspaces:
     - name: source
 
@@ -85,6 +90,8 @@ spec:
           value: $(context.pipeline.name)
         - name: pipelinerun_name
           value: $(context.pipelineRun.name)
+        - name: app
+          value: "$(params.application)"
 
     - name: git-clone
       taskRef:

--- a/charts/tekton-pipelines/templates/buildkit/trigger-template.yaml
+++ b/charts/tekton-pipelines/templates/buildkit/trigger-template.yaml
@@ -71,6 +71,8 @@ spec:
 
       params:
         {{- include "pipeline.defaultTTBoundParams" (dict  "docker" true "kubernetes" true)  | nindent 8 }}
+        - name: app
+          value: "$(tt.params.application)"
         - name: project
           value: "$(tt.params.project)"
         - name: namespace

--- a/charts/tekton-pipelines/templates/buildkit/trigger-template.yaml
+++ b/charts/tekton-pipelines/templates/buildkit/trigger-template.yaml
@@ -37,6 +37,14 @@ spec:
     - name: sentry_project_name
       description: name of the project in Sentry
 
+    - name: terminate-concurrent-runs
+      description: whether to terminate concurrent runs of the same pipeline
+      default: ""
+
+    - name: commit_timestamp
+      description: Timestamp of the commit that triggered the current pipeline.
+      default: ""
+
   resourcetemplates:
   - kind: PipelineRun
     apiVersion: tekton.dev/v1beta1
@@ -47,6 +55,8 @@ spec:
         project: $(tt.params.project)
         environment: $(tt.params.environment)
         component: $(tt.params.component)
+      annotations:
+        pipeline.tekton.dev/commit-timestamp: $(tt.params.commit_timestamp)
     spec:
       serviceAccountName: $(tt.params.application)-build-pipeline-sa
 
@@ -79,6 +89,10 @@ spec:
           value: "$(tt.params.sentry_project_name)"
         - name: kubernetes_repository_ssh_url
           value: "$(tt.params.kubernetes_repository_ssh_url)"
+        - name: terminate-concurrent-runs
+          value: "$(tt.params.terminate-concurrent-runs)"
+        - name: commit_timestamp
+          value: "$(tt.params.commit_timestamp)"
 
       workspaces:
         {{- include "pipeline.defaultWorkspaces" . | nindent 8 }}

--- a/charts/tekton-pipelines/templates/buildkit/trigger-template.yaml
+++ b/charts/tekton-pipelines/templates/buildkit/trigger-template.yaml
@@ -71,8 +71,6 @@ spec:
 
       params:
         {{- include "pipeline.defaultTTBoundParams" (dict  "docker" true "kubernetes" true)  | nindent 8 }}
-        - name: app
-          value: "$(tt.params.application)"
         - name: project
           value: "$(tt.params.project)"
         - name: namespace

--- a/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
@@ -107,11 +107,6 @@ spec:
       type: string
       default: ""
 
-    - name: app
-      type: string
-      description: name of the application
-      default: ""
-
   workspaces:
     - name: source
 
@@ -133,8 +128,8 @@ spec:
           value: $(context.pipeline.name)
         - name: pipelinerun_name
           value: $(context.pipelineRun.name)
-        - name: app
-          value: $(params.app)
+        - name: application
+          value: "$(params.application)"
 
     - name: git-clone
       taskRef:

--- a/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
@@ -98,10 +98,37 @@ spec:
       description: name of the dir where frontend sourcemaps would be stored in workspace
       default: "sourcemaps"
 
+    - name: terminate-concurrent-runs
+      description: whether to terminate concurrent runs of the same pipeline
+      default: ""
+
+    - name: commit_timestamp
+      description: Timestamp of the commit that triggered the current pipeline.
+      type: string
+      default: ""
+
   workspaces:
     - name: source
 
   tasks:
+    - name: terminate-concurrent-runs
+      when:
+        - input: $(params.terminate-concurrent-runs)
+          operator: in
+          values:
+            - 'true'
+      taskRef:
+        name: terminate-concurrent-runs
+      params:
+        - name: commit_timestamp
+          value: $(params.commit_timestamp)
+        - name: namespace
+          value: $(params.namespace)
+        - name: pipeline_name
+          value: $(context.pipeline.name)
+        - name: pipelinerun_name
+          value: $(context.pipelineRun.name)
+
     - name: git-clone
       taskRef:
         name: git-clone

--- a/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/pipelines/_buildpack.yaml
@@ -107,6 +107,11 @@ spec:
       type: string
       default: ""
 
+    - name: app
+      type: string
+      description: name of the application
+      default: ""
+
   workspaces:
     - name: source
 
@@ -128,6 +133,8 @@ spec:
           value: $(context.pipeline.name)
         - name: pipelinerun_name
           value: $(context.pipelineRun.name)
+        - name: app
+          value: $(params.app)
 
     - name: git-clone
       taskRef:

--- a/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
@@ -77,7 +77,6 @@ spec:
 
     - name: commit_timestamp
       description: Timestamp of the commit that triggered the current pipeline.
-      type: string
       default: ""
 
   resourcetemplates:
@@ -90,6 +89,8 @@ spec:
         project: $(tt.params.project)
         environment: $(tt.params.environment)
         component: $(tt.params.component)
+      annotations:
+        pipeline.tekton.dev/commit-timestamp: $(tt.params.commit_timestamp)
     spec:
       serviceAccountName: $(tt.params.application)-build-pipeline-sa
       taskRunSpecs:
@@ -137,8 +138,8 @@ spec:
           value: "$(tt.params.sentry_project_name)"
         - name: kubernetes_repository_ssh_url
           value: "$(tt.params.kubernetes_repository_ssh_url)"
-        - name: terminate_concurrent_runs
-          value: "$(tt.params.terminate_concurrent_runs)"
+        - name: terminate-concurrent-runs
+          value: "$(tt.params.terminate-concurrent-runs)"
         - name: commit_timestamp
           value: "$(tt.params.commit_timestamp)"
 

--- a/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
@@ -102,8 +102,6 @@ spec:
         name: {{ .pipeline.name }}
       params:
         {{- include "pipeline.defaultTTBoundParams" (dict  "docker" true "kubernetes" true)  | nindent 8 }}
-        - name: app
-          value: "$(tt.params.application)"
         - name: project
           value: "$(tt.params.project)"
         - name: namespace

--- a/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
@@ -71,6 +71,15 @@ spec:
     - name: sentry_project_name
       description: name of the project in Sentry
 
+    - name: terminate-concurrent-runs
+      description: whether to terminate concurrent runs of the same pipeline
+      default: ""
+
+    - name: commit_timestamp
+      description: Timestamp of the commit that triggered the current pipeline.
+      type: string
+      default: ""
+
   resourcetemplates:
   - kind: PipelineRun
     apiVersion: tekton.dev/v1beta1
@@ -128,6 +137,10 @@ spec:
           value: "$(tt.params.sentry_project_name)"
         - name: kubernetes_repository_ssh_url
           value: "$(tt.params.kubernetes_repository_ssh_url)"
+        - name: terminate_concurrent_runs
+          value: "$(tt.params.terminate_concurrent_runs)"
+        - name: commit_timestamp
+          value: "$(tt.params.commit_timestamp)"
 
       workspaces:
         {{- include "pipeline.defaultWorkspaces" . | nindent 8 }}

--- a/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
+++ b/charts/tekton-pipelines/templates/buildpacks/trigger-templates/_buildpack.yaml
@@ -102,6 +102,8 @@ spec:
         name: {{ .pipeline.name }}
       params:
         {{- include "pipeline.defaultTTBoundParams" (dict  "docker" true "kubernetes" true)  | nindent 8 }}
+        - name: app
+          value: "$(tt.params.application)"
         - name: project
           value: "$(tt.params.project)"
         - name: namespace

--- a/charts/tekton-pipelines/templates/common/tasks/terminate-concurrent-runs.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/terminate-concurrent-runs.yaml
@@ -32,7 +32,7 @@ spec:
     - name: pipelinerun_name
       description: Name of the current PipelineRun.
       type: string
-    - name: app
+    - name: application
       description: Name of the application.
       type: string
   steps:
@@ -58,7 +58,7 @@ spec:
         - name: pipelinerun_name
           value: $(params.pipelinerun_name)
         - name: app
-          value: $(params.app)
+          value: $(params.application)
       script: |
         #!/usr/bin/env sh
         set -eu
@@ -79,7 +79,7 @@ spec:
         if [ -n "${running}" ]; then
           echo "Delete previously initiated pipelineruns of the ${pipeline_name}:"
           for pipelinerun in ${running}; do
-            kubectl delete pipelinerun ${pipelinerun} -n ${namespace}
+            kubectl delete pipelinerun ${pipelinerun} -n ${namespace} --ignore-not-found=true
           done
         else
           echo "No concurrent running pipelineruns detected."

--- a/charts/tekton-pipelines/templates/common/tasks/terminate-concurrent-runs.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/terminate-concurrent-runs.yaml
@@ -32,6 +32,9 @@ spec:
     - name: pipelinerun_name
       description: Name of the current PipelineRun.
       type: string
+    - name: app
+      description: Name of the application.
+      type: string
   steps:
     - name: execute
       image: {{ .Values.images.kubectl }}
@@ -54,6 +57,8 @@ spec:
           value: $(params.pipeline_name)
         - name: pipelinerun_name
           value: $(params.pipelinerun_name)
+        - name: app
+          value: $(params.app)
       script: |
         #!/usr/bin/env sh
         set -eu
@@ -68,6 +73,7 @@ spec:
           yq '.items[]
             | select(.status.conditions[0].reason == "Running" and .metadata.name != strenv(name))
             | select(.metadata.annotations["pipeline.tekton.dev/commit-timestamp"] <= strenv(ts))
+            | select(.metadata.labels.app == strenv(app))
             | .metadata.name')
 
         if [ -n "${running}" ]; then

--- a/charts/tekton-pipelines/templates/common/tasks/terminate-concurrent-runs.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/terminate-concurrent-runs.yaml
@@ -1,0 +1,80 @@
+---
+apiVersion: tekton.dev/v1
+kind: Task
+metadata:
+  name: terminate-concurrent-runs
+  namespace: {{ .Release.Namespace }}
+  labels:
+    tekton.dev/utils: 'true'
+    {{- include "task.labels" . | nindent 4 }}
+spec:
+  description: |
+    Terminate concurrent runs of the same pipeline.
+
+    That is necessary to prevent race conditions when we build the same repository with multiple commits sent in sequence.
+    For example developer can create commit A, B (in chronological order) and push with little delay between them.
+    - where B fixes some issues of A
+    - but A still deployed if A pipeline execution takes longer than pipelinerun triggered by commit B
+
+    Solution:
+    - search for the same pipelineruns in the `Running` state by the `tekton.dev/pipeline` label and delete them.
+
+  params:
+    - name: commit_timestamp
+      description: Timestamp of the commit that triggered the current pipeline.
+      type: string
+    - name: namespace
+      description: Namespace executing pipelineruns.
+      type: string
+    - name: pipeline_name
+      description: Name of the pipeline to check for active PipelineRuns.
+      type: string
+    - name: pipelinerun_name
+      description: Name of the current PipelineRun.
+      type: string
+  steps:
+    - name: execute
+      image: {{ .Values.images.kubectl }}
+      imagePullPolicy: IfNotPresent
+      securityContext:
+        runAsUser: 0
+        runAsGroup: 0
+        runAsNonRoot: false
+        privileged: false
+        allowPrivilegeEscalation: false
+        capabilities:
+          drop:
+            - ALL
+      env:
+        - name: commit_timestamp
+          value: $(params.commit_timestamp)
+        - name: namespace
+          value: $(params.namespace)
+        - name: pipeline_name
+          value: $(params.pipeline_name)
+        - name: pipelinerun_name
+          value: $(params.pipelinerun_name)
+      script: |
+        #!/usr/bin/env sh
+        set -eu
+        echo "Checking for running concurrent pipelineruns of the pipeline ${pipeline_name}..."
+
+        export name="${pipelinerun_name}"
+        export ts="${commit_timestamp}"
+        running=$(kubectl get pipelinerun \
+          -n ${namespace} \
+          -l tekton.dev/pipeline=${pipeline_name} \
+          -o yaml | \
+          yq '.items[]
+            | select(.status.conditions[0].reason == "Running" and .metadata.name != strenv(name))
+            | select(.metadata.annotations["pipeline.tekton.dev/commit-timestamp"] <= strenv(ts))
+            | .metadata.name')
+
+        if [ -n "${running}" ]; then
+          echo "Delete previously initiated pipelineruns of the ${pipeline_name}:"
+          for pipelinerun in ${running}; do
+            kubectl delete pipelinerun ${pipelinerun} -n ${namespace}
+          done
+        else
+          echo "No concurrent running pipelineruns detected."
+        fi

--- a/charts/tekton-pipelines/templates/common/tasks/terminate-concurrent-runs.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/terminate-concurrent-runs.yaml
@@ -49,7 +49,7 @@ spec:
         - name: commit_timestamp
           value: $(params.commit_timestamp)
         - name: namespace
-          value: $(params.namespace)
+          value: {{ .Release.Namespace }} # differ from infra-v3: use release namespace instead of param because pipelines are executed in the same namespace as tekton-pipelines chart
         - name: pipeline_name
           value: $(params.pipeline_name)
         - name: pipelinerun_name

--- a/charts/tekton-pipelines/templates/common/tasks/terminate-concurrent-runs.yaml
+++ b/charts/tekton-pipelines/templates/common/tasks/terminate-concurrent-runs.yaml
@@ -62,7 +62,7 @@ spec:
       script: |
         #!/usr/bin/env sh
         set -eu
-        echo "Checking for running concurrent pipelineruns of the pipeline ${pipeline_name}..."
+        echo "Checking for running concurrent pipelineruns of the pipeline ${pipeline_name}... for app ${app}"
 
         export name="${pipelinerun_name}"
         export ts="${commit_timestamp}"

--- a/charts/tekton-pipelines/templates/common/triggers/github-trigger-binding.yaml
+++ b/charts/tekton-pipelines/templates/common/triggers/github-trigger-binding.yaml
@@ -25,3 +25,5 @@ spec:
     value: $(body.repository.ssh_url)
   - name: branch
     value: $(body.ref)
+  - name: commit_timestamp
+    value: $(body.head_commit.timestamp)

--- a/charts/tekton-pipelines/templates/kaniko/pipeline.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/pipeline.yaml
@@ -90,6 +90,8 @@ spec:
           value: $(context.pipeline.name)
         - name: pipelinerun_name
           value: $(context.pipelineRun.name)
+        - name: app
+          value: "$(params.application)"
 
     - name: git-clone
       taskRef:

--- a/charts/tekton-pipelines/templates/kaniko/pipeline.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/pipeline.yaml
@@ -55,10 +55,37 @@ spec:
       type: string
       description: git repository ssh url for kubernetes manifests repo
 
+    - name: terminate-concurrent-runs
+      description: whether to terminate concurrent runs of the same pipeline
+      default: ""
+
+    - name: commit_timestamp
+      description: Timestamp of the commit that triggered the current pipeline.
+      type: string
+      default: ""
+
   workspaces:
     - name: source
 
   tasks:
+    - name: terminate-concurrent-runs
+      when:
+        - input: $(params.terminate-concurrent-runs)
+          operator: in
+          values:
+            - 'true'
+      taskRef:
+        name: terminate-concurrent-runs
+      params:
+        - name: commit_timestamp
+          value: $(params.commit_timestamp)
+        - name: namespace
+          value: $(params.namespace)
+        - name: pipeline_name
+          value: $(context.pipeline.name)
+        - name: pipelinerun_name
+          value: $(context.pipelineRun.name)
+
     - name: git-clone
       taskRef:
         name: git-clone

--- a/charts/tekton-pipelines/templates/kaniko/pipeline.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/pipeline.yaml
@@ -64,6 +64,11 @@ spec:
       type: string
       default: ""
 
+    - name: app
+      type: string
+      description: name of the application
+      default: ""
+
   workspaces:
     - name: source
 

--- a/charts/tekton-pipelines/templates/kaniko/pipeline.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/pipeline.yaml
@@ -64,11 +64,6 @@ spec:
       type: string
       default: ""
 
-    - name: app
-      type: string
-      description: name of the application
-      default: ""
-
   workspaces:
     - name: source
 
@@ -90,8 +85,8 @@ spec:
           value: $(context.pipeline.name)
         - name: pipelinerun_name
           value: $(context.pipelineRun.name)
-        - name: app
-          value: "$(params.application)"
+        - name: application
+          value: $(params.application)
 
     - name: git-clone
       taskRef:

--- a/charts/tekton-pipelines/templates/kaniko/trigger-template.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/trigger-template.yaml
@@ -69,6 +69,8 @@ spec:
         name: kaniko-build-pipeline
       params:
         {{- include "pipeline.defaultTTBoundParams" (dict  "docker" true "kubernetes" true)  | nindent 8 }}
+        - name: app
+          value: "$(tt.params.application)"
         - name: project
           value: "$(tt.params.project)"
         - name: namespace

--- a/charts/tekton-pipelines/templates/kaniko/trigger-template.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/trigger-template.yaml
@@ -37,6 +37,14 @@ spec:
     - name: sentry_project_name
       description: name of the project in Sentry
 
+    - name: terminate-concurrent-runs
+      description: whether to terminate concurrent runs of the same pipeline
+      default: ""
+
+    - name: commit_timestamp
+      description: Timestamp of the commit that triggered the current pipeline.
+      default: ""
+
   resourcetemplates:
   - kind: PipelineRun
     apiVersion: tekton.dev/v1beta1
@@ -47,6 +55,8 @@ spec:
         project: $(tt.params.project)
         environment: $(tt.params.environment)
         component: $(tt.params.component)
+      annotations:
+        pipeline.tekton.dev/commit-timestamp: $(tt.params.commit_timestamp)
     spec:
       serviceAccountName: $(tt.params.application)-build-pipeline-sa
 
@@ -77,6 +87,10 @@ spec:
           value: "$(tt.params.sentry_project_name)"
         - name: kubernetes_repository_ssh_url
           value: "$(tt.params.kubernetes_repository_ssh_url)"
+        - name: terminate-concurrent-runs
+          value: "$(tt.params.terminate-concurrent-runs)"
+        - name: commit_timestamp
+          value: "$(tt.params.commit_timestamp)"
 
       workspaces:
         {{- include "pipeline.defaultWorkspaces" . | nindent 8 }}

--- a/charts/tekton-pipelines/templates/kaniko/trigger-template.yaml
+++ b/charts/tekton-pipelines/templates/kaniko/trigger-template.yaml
@@ -69,8 +69,6 @@ spec:
         name: kaniko-build-pipeline
       params:
         {{- include "pipeline.defaultTTBoundParams" (dict  "docker" true "kubernetes" true)  | nindent 8 }}
-        - name: app
-          value: "$(tt.params.application)"
         - name: project
           value: "$(tt.params.project)"
         - name: namespace


### PR DESCRIPTION
### Summary

Task: [RENEWAIRE-1280](https://saritasa.atlassian.net/browse/RENEWAIRE-1280)

Releases:
```
tekton-pipelines: 2.2.19
tekton-apps: 2.1.10
```

<!--
Description should contain link to valid task in Jira, short description of the implemented feature.
Please ensure that actions passed.
-->

- sync usummit terminate-concurrent-task: https://github.com/saritasa-nest/usummit-kubernetes-aws/pull/323
- task was needed for Renewaire devs because they sometimes merge many PRs at once and that leads to race conditions where they don't know if latest PR was ultimately the one applied in dev env


### Modifications compared to usummit:
- infra-v2 uses SAs for each component, so I needed to add required perms in tekton-apps chart
- I added the task to Kaniko, buildpack and buildkit pipelines
- didn't add it to wordpress pipeline as it's only a deploy task, although I can add it if necessary 
- By default this task is off (defined by the `when` keyword), so it needs to be enabled in each component in tekton-apps using:

```yaml
            triggerBinding:
              - name: terminate-concurrent-runs
                value: 'true'
```
(we could enable it by default if the plan is to enable this feature in all projects)


Tests using CI experiments:

1. Frontend buildpack
https://tekton.saritasa.rocks/#/namespaces/ci-experiments/pipelineruns/saritasa-ci-experiments-frontend-dev-build-pipeline-run-t997x?pipelineTask=terminate-concurrent-runs&step=execute&view=logs
<img width="2470" height="1148" alt="image" src="https://github.com/user-attachments/assets/c97dc7d9-e1e7-4ec0-b8ab-c06d097abe41" />
(set -x was added manually just to show pipeline values, it's not enabled by default)

2. backend buildkit:
https://tekton.saritasa.rocks/#/namespaces/ci-experiments/pipelineruns/saritasa-ci-experiments-buildkit-backend-dev-buildkit-builjqgc6?pipelineTask=terminate-concurrent-runs&step=execute
<img width="3428" height="1344" alt="image" src="https://github.com/user-attachments/assets/97180668-b6c3-4a0b-a583-c9b1ba609285" />

3. Normal behaviour

<img width="3344" height="1206" alt="image" src="https://github.com/user-attachments/assets/6b4f190b-e4a5-4a3f-b63d-9a46584fe75f" />

4. Kaniko backend 
https://tekton.saritasa.rocks/#/namespaces/ci-experiments/pipelineruns/saritasa-ci-experiments-buildkit-backend-dev-buildkit-builjqgc6?pipelineTask=terminate-concurrent-runs&step=execute

<img width="3400" height="1372" alt="image" src="https://github.com/user-attachments/assets/53092767-d578-40ee-b954-decd3489c0a2" />

5. When the task is not enabled
https://tekton.saritasa.rocks/#/namespaces/ci-experiments/pipelineruns/saritasa-ci-experiments2-php-backend-dev-build-pipeline-rup6qjz?pipelineTask=terminate-concurrent-runs&step=execute
<img width="3198" height="1152" alt="image" src="https://github.com/user-attachments/assets/b3862f6d-92d7-4057-a16d-953ba109dbce" />



[RENEWAIRE-1280]: https://saritasa.atlassian.net/browse/RENEWAIRE-1280?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ