### PR TITLE
feat: update copy-requirements step SD-373

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## 2026-06-103
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/192)
+- Update copy-requirements step for Django pipeline
+
 ## 2026-03-16
 
 - [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/188)

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.18
+version: 2.2.19-dev.1
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.19-dev.1
+version: 2.2.20-dev.1
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.20-dev.1
+version: 2.2.20
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.19](https://img.shields.io/badge/Version-2.2.19-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.20-dev.1](https://img.shields.io/badge/Version-2.2.20--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.20-dev.1](https://img.shields.io/badge/Version-2.2.20--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.20](https://img.shields.io/badge/Version-2.2.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -332,10 +332,10 @@ buildpacks:
               echo "'uv.lock' is found, preparing requirements.txt"
               if [[ "$(params.environment)" == "dev" ]]; then
                 echo "Export with 'dev' targets dependencies"
-                uv export --format requirements-txt --all-groups --output-file requirements.txt
+                uv export --format requirements-txt --group dev --output-file requirements.txt
                 exit 0
               fi
-              uv export --format requirements-txt --no-dev --output-file requirements.txt
+              uv export --format requirements-txt --output-file requirements.txt
               exit 0
             fi
 

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -332,7 +332,7 @@ buildpacks:
               echo "'uv.lock' is found, preparing requirements.txt"
               if [[ "$(params.environment)" == "dev" ]]; then
                 echo "Export with 'dev' targets dependencies"
-                uv export --format requirements-txt --output-file requirements.txt
+                uv export --format requirements-txt --all-groups --output-file requirements.txt
                 exit 0
               fi
               uv export --format requirements-txt --no-dev --output-file requirements.txt


### PR DESCRIPTION
### Summary

Task: [SD-373](https://saritasa.atlassian.net/browse/SD-373)

Update copy-requirements step for Django pipeline

Incomming changes for uv.lock from django boilerplate brakes current build workflow and some packages are not installed during this step (django-toolbox as direct case) what leads to failed deployments.
According to consultations with python dev team they proposed to update `uv sync` to install dev group for dev builds explicitly to resolve this problem.



[SD-373]: https://saritasa.atlassian.net/browse/SD-373?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ