### PR TITLE
feat: update `uv` handling in buildpack-django pipeline, SD-1610

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 2026-07-15
+
+[dev]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/194)
+- Update how the buildpack-django pipeline handles uv
+
 ## 2026-06-08
 
 [dev]

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.20
+version: 2.2.21-dev.1
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.21-dev.3
+version: 2.2.21
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.21-dev.1
+version: 2.2.21-dev.2
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/Chart.yaml
+++ b/charts/tekton-pipelines/Chart.yaml
@@ -6,7 +6,7 @@ type: application
 # This is the chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
 # Versions are expected to follow Semantic Versioning (https://semver.org/)
-version: 2.2.21-dev.2
+version: 2.2.21-dev.3
 
 maintainers:
   - url: https://www.saritasa.com/

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.21-dev.1](https://img.shields.io/badge/Version-2.2.21--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.21-dev.2](https://img.shields.io/badge/Version-2.2.21--dev.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.21-dev.2](https://img.shields.io/badge/Version-2.2.21--dev.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.21-dev.3](https://img.shields.io/badge/Version-2.2.21--dev.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.20](https://img.shields.io/badge/Version-2.2.20-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.21-dev.1](https://img.shields.io/badge/Version-2.2.21--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/README.md
+++ b/charts/tekton-pipelines/README.md
@@ -31,7 +31,7 @@ saritasa-tekton-pipelines
 
 ## `chart.version`
 
-![Version: 2.2.21-dev.3](https://img.shields.io/badge/Version-2.2.21--dev.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
+![Version: 2.2.21](https://img.shields.io/badge/Version-2.2.21-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square)
 
 ## Maintainers
 

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -297,15 +297,27 @@ buildpacks:
             mkdir -p "${env_dir}"
 
             # Default values for BP environment variables
+            # If the variables are not defined in the buildpack_env_vars parameter, these values will be used
             declare -A env_vars=(
+              # paketo-buildpacks/poetry-install:
+              # configure which groups from pyproject.toml file will be installed
               ["BP_POETRY_INSTALL_ONLY"]="main"
+              # paketo-buildpacks/python-package-managers-run(uv):
+              # exit with an error if the lock file is not up-to-date with the pyproject.toml
               ["BP_UV_LOCKED"]="1"
+              # paketo-buildpacks/python-package-managers-run(uv):
+              # instruct uv to compile Python source files to bytecode after installation (to improve startup time)
               ["BP_UV_COMPILE_BYTECODE"]="1"
             )
 
             # Default values for environment-specific BP variables
+            # These values are later merged with env_vars based on the current environment, adding keys or overriding common values
             declare -A env_overrides=(
+              # paketo-buildpacks/poetry-install:
+              # configure which groups from pyproject.toml file will be installed
               ["dev|BP_POETRY_INSTALL_ONLY"]="main,dev"
+              # paketo-buildpacks/python-package-managers-run(uv):
+              # configure which groups from pyproject.toml file will be installed
               ["dev|BP_UV_INSTALL_GROUPS"]="dev"
             )
 

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -291,29 +291,52 @@ buildpacks:
           script: |
             #!/usr/bin/env bash
             set -eo pipefail
+
             buildpack_env_vars="$(params.buildpack_env_vars)"
             env_dir="${source_path}/${platform_dir}/env"
-            mkdir -p ${env_dir}
+            mkdir -p "${env_dir}"
 
-            # Add `BP_POETRY_INSTALL_ONLY` variable that specifies
-            # which package groups should be installed during build
-            if ! echo "${buildpack_env_vars}" | grep -q "BP_POETRY_INSTALL_ONLY"; then
-              echo "Adding BP_POETRY_INSTALL_ONLY environment variable"
-              bp_poetry_install_only="main"
-              if [[ "${environment}" == "dev" ]]; then
-                bp_poetry_install_only="${bp_poetry_install_only},dev"
+            # Default values for BP environment variables
+            declare -A env_vars=(
+              ["BP_POETRY_INSTALL_ONLY"]="main"
+              ["BP_UV_LOCKED"]="1"
+              ["BP_UV_COMPILE_BYTECODE"]="1"
+            )
+
+            # Default values for environment-specific BP variables
+            declare -A env_overrides=(
+              ["dev|BP_POETRY_INSTALL_ONLY"]="main,dev"
+              ["dev|BP_UV_INSTALL_GROUPS"]="dev"
+            )
+
+            # Apply environment-dependent overrides to env_vars
+            for key in "${!env_overrides[@]}"; do
+              key_environment="${key%%|*}"
+              key_name="${key#*|}"
+              if [[ "${environment}" == "${key_environment}" ]]; then
+                env_vars["${key_name}"]="${env_overrides[${key}]}"
               fi
-              buildpack_env_vars="BP_POETRY_INSTALL_ONLY=${bp_poetry_install_only};${buildpack_env_vars}"
-              echo "Added BP_POETRY_INSTALL_ONLY=${bp_poetry_install_only}"
-            fi
+            done
 
-            # parse environment variables and add them to the platform directory
-            IFS=';' read -ra env_vars <<< "${buildpack_env_vars}"
-            for env_var in "${env_vars[@]}"; do
-              key=$(echo ${env_var} | cut -d'=' -f1)
-              value=$(echo ${env_var} | cut -d'=' -f2-)
-              echo "Creating ${env_dir}/${key} with value: ${value}"
-              echo "$value" > "${env_dir}/${key}"
+            # If the variables from env_vars are not defined in buildpack_env_vars,
+            # add them with the default values specified above
+            for env_var in "${!env_vars[@]}"; do
+              if [[ ";${buildpack_env_vars}" == *";${env_var}="* ]]; then
+                echo "[!] Variable ${env_var} is set explicitly, ignoring defaults"
+                continue
+              fi
+              default_value="${env_vars[${env_var}]}"
+              buildpack_env_vars="${env_var}=${default_value}${buildpack_env_vars:+;${buildpack_env_vars}}"
+            done
+
+            # Parse buildpack_env_vars to add them to the platform directory
+            # https://github.com/buildpacks/spec/blob/b745fcfd90d7139d6a04cca2878b47ec402be943/platform.md#user-provided-variables
+            IFS=';' read -ra env_pairs <<< "${buildpack_env_vars}"
+            for env_pair in "${env_pairs[@]}"; do
+              key="${env_pair%%=*}"
+              value="${env_pair#*=}"
+              echo "Creating ${env_dir}/${key} with the value: ${value}"
+              echo "${value}" > "${env_dir}/${key}"
             done
         - name: copy-requirements
           image: docker.io/saritasallc/python-ci:0.0.2
@@ -323,21 +346,6 @@ buildpacks:
           script: |
             #!/usr/bin/env bash
             set -eo pipefail
-
-            if [[ -f uv.lock ]]; then
-              if [[ ! $(command -v uv) ]]; then
-                echo "uv is not installed or not in PATH. Halting execution."
-                exit 1
-              fi
-              echo "'uv.lock' is found, preparing requirements.txt"
-              if [[ "$(params.environment)" == "dev" ]]; then
-                echo "Export with 'dev' targets dependencies"
-                uv export --format requirements-txt --group dev --output-file requirements.txt
-                exit 0
-              fi
-              uv export --format requirements-txt --output-file requirements.txt
-              exit 0
-            fi
 
             if ls requirements/$(params.environment)*.txt >/dev/null 2>&1; then
               echo "'requirements' folder is found, preparing requirements.txt"

--- a/charts/tekton-pipelines/values.yaml
+++ b/charts/tekton-pipelines/values.yaml
@@ -336,7 +336,7 @@ buildpacks:
               key="${env_pair%%=*}"
               value="${env_pair#*=}"
               echo "Creating ${env_dir}/${key} with the value: ${value}"
-              echo "${value}" > "${env_dir}/${key}"
+              echo -n "${value}" > "${env_dir}/${key}"
             done
         - name: copy-requirements
           image: docker.io/saritasallc/python-ci:0.0.2


### PR DESCRIPTION
### Summary

Task: [SD-1610](https://saritasa.atlassian.net/browse/SD-1610)

Changes:
- enforce best practices for `uv` by default (as requested by @TheSuperiorStanislav)
- add the necessary environment variables for the updated buildpacks
- remove the export of `requirements.txt` for `uv`

Tested on saritasa-ci-experiments-django-backend:

<img width="1237" height="130" src="https://github.com/user-attachments/assets/42015f57-607e-49f3-b7d5-7f7220d0c643" />

[SD-1610]: https://saritasa.atlassian.net/browse/SD-1610?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ