### PR TITLE
feat: eol arm64, dynamic discovery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 # Changelog
 
+## 2026-07-31
+
+[dev]
+
+- [associated PR](https://github.com/saritasa-nest/saritasa-devops-helm-charts/pull/197)
+- Update EOL chart to 1.0.7
+- Update EOL app to 1.2.0 with ARM64 and dynamic discovery
+
 ## 2026-07-22
 
 [dev]

--- a/charts/eol-exporter/Chart.yaml
+++ b/charts/eol-exporter/Chart.yaml
@@ -14,8 +14,16 @@ description: |
   # https://endoflife.date/api/{product}.json
   eks:
     product: eks
-    version: '1.30'
+    version: dynamic
     comment: EKS
+  postgres:
+    product: postgresql
+    version: dynamic
+    comment: database
+  redis:
+    product: amazon-elasticache-redis
+    version: dynamic
+    comment: cache
   django:
     product: django
     version: '5.1'
@@ -34,6 +42,17 @@ description: |
     product: python
     version: '3.11'
     dockerfile: https://github.com/saritasa-nest/allstar-elevator-we-backend/blob/develop/Dockerfile
+
+  services:
+    - aws/eks
+    - aws/rds
+    - aws/elasticache
+  regions:
+    - us-west-2
+  searchByTag:
+    Environment: prod
+  exclude:
+    - '-test$'
   ```
 
   Check https://github.com/saritasa-nest/saritasa-devops-tools-eol-exporter/blob/main/config.yaml.example
@@ -49,6 +68,10 @@ description: |
   Exporter now supports dynamically fetching current version of products for:
   - AWS RDS
   - AWS EKS
+  - AWS ElastiCache
+
+  Dynamic AWS discovery supports `aws/eks`, `aws/rds`, and `aws/elasticache`
+  services with optional `regions`, `searchByTag`, and `exclude` top-level keys.
 
   If you are using any of the these products, then remember to enable the Service account and attach a role with the following permissions:
 
@@ -70,7 +93,10 @@ description: |
               "Effect": "Allow",
               "Action": [
                   "rds:DescribeDBInstances",
-                  "eks:DescribeCluster"
+                  "eks:DescribeCluster",
+                  "elasticache:DescribeCacheClusters",
+                  "elasticache:DescribeReplicationGroups",
+                  "tag:GetResources"
               ],
               "Resource": "*"
           }
@@ -138,7 +164,7 @@ type: application
 
 # The chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.7-dev.1
+version: 1.0.7-dev.2
 appVersion: 1.2.0
 
 dependencies:

--- a/charts/eol-exporter/Chart.yaml
+++ b/charts/eol-exporter/Chart.yaml
@@ -164,7 +164,7 @@ type: application
 
 # The chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.7-dev.2
+version: 1.0.7
 appVersion: 1.2.0
 
 dependencies:

--- a/charts/eol-exporter/Chart.yaml
+++ b/charts/eol-exporter/Chart.yaml
@@ -138,8 +138,8 @@ type: application
 
 # The chart version. This version number should be incremented each time you make changes
 # to the chart and its templates, including the app version.
-version: 1.0.6
-appVersion: 1.1.1
+version: 1.0.7-dev.1
+appVersion: 1.2.0
 
 dependencies:
   # https://artifacthub.io/packages/helm/stakater/application?modal=values&compare-to=6.14.0

--- a/charts/eol-exporter/README.md
+++ b/charts/eol-exporter/README.md
@@ -1,7 +1,7 @@
 
 # eol-prometheus-exporter
 
-![Version: 1.0.7-dev.1](https://img.shields.io/badge/Version-1.0.7--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 1.0.7-dev.2](https://img.shields.io/badge/Version-1.0.7--dev.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 End of life prometheus exporter.
 
@@ -16,8 +16,16 @@ You must supply a valid configmap with a list of products with its versions:
 # https://endoflife.date/api/{product}.json
 eks:
   product: eks
-  version: '1.30'
+  version: dynamic
   comment: EKS
+postgres:
+  product: postgresql
+  version: dynamic
+  comment: database
+redis:
+  product: amazon-elasticache-redis
+  version: dynamic
+  comment: cache
 django:
   product: django
   version: '5.1'
@@ -36,6 +44,17 @@ python-allstar-elevator-we:
   product: python
   version: '3.11'
   dockerfile: https://github.com/saritasa-nest/allstar-elevator-we-backend/blob/develop/Dockerfile
+
+services:
+  - aws/eks
+  - aws/rds
+  - aws/elasticache
+regions:
+  - us-west-2
+searchByTag:
+  Environment: prod
+exclude:
+  - '-test$'
 ```
 
 Check https://github.com/saritasa-nest/saritasa-devops-tools-eol-exporter/blob/main/config.yaml.example
@@ -51,6 +70,10 @@ Optionally, you can add any extra field and it will be added as a label in the m
 Exporter now supports dynamically fetching current version of products for:
 - AWS RDS
 - AWS EKS
+- AWS ElastiCache
+
+Dynamic AWS discovery supports `aws/eks`, `aws/rds`, and `aws/elasticache`
+services with optional `regions`, `searchByTag`, and `exclude` top-level keys.
 
 If you are using any of the these products, then remember to enable the Service account and attach a role with the following permissions:
 
@@ -72,7 +95,10 @@ IAM permissions:
             "Effect": "Allow",
             "Action": [
                 "rds:DescribeDBInstances",
-                "eks:DescribeCluster"
+                "eks:DescribeCluster",
+                "elasticache:DescribeCacheClusters",
+                "elasticache:DescribeReplicationGroups",
+                "tag:GetResources"
             ],
             "Resource": "*"
         }
@@ -212,7 +238,7 @@ endoflife_failed_configs{} == 1
 | exporter.deployment.strategy.type | string | `"RollingUpdate"` |  |
 | exporter.deployment.tolerations | list | `[]` |  |
 | exporter.deployment.topologySpreadConstraints | object | `{}` |  |
-| exporter.deployment.volumeMounts.config.mountPath | string | `"/workspace/app/config.yaml"` |  |
+| exporter.deployment.volumeMounts.config.mountPath | string | `"/app/config.yaml"` |  |
 | exporter.deployment.volumeMounts.config.subPath | string | `"config.yaml"` |  |
 | exporter.deployment.volumes.config.configMap.name | string | `"eol-exporter-config"` |  |
 | exporter.enabled | bool | `true` |  |

--- a/charts/eol-exporter/README.md
+++ b/charts/eol-exporter/README.md
@@ -1,7 +1,7 @@
 
 # eol-prometheus-exporter
 
-![Version: 1.0.7-dev.2](https://img.shields.io/badge/Version-1.0.7--dev.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
+![Version: 1.0.7](https://img.shields.io/badge/Version-1.0.7-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 End of life prometheus exporter.
 

--- a/charts/eol-exporter/README.md
+++ b/charts/eol-exporter/README.md
@@ -1,7 +1,7 @@
 
 # eol-prometheus-exporter
 
-![Version: 1.0.6](https://img.shields.io/badge/Version-1.0.6-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.1.1](https://img.shields.io/badge/AppVersion-1.1.1-informational?style=flat-square)
+![Version: 1.0.7-dev.1](https://img.shields.io/badge/Version-1.0.7--dev.1-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 1.2.0](https://img.shields.io/badge/AppVersion-1.2.0-informational?style=flat-square)
 
 End of life prometheus exporter.
 
@@ -148,9 +148,6 @@ endoflife_failed_configs{} == 1
 | exporter.applicationName | string | `"eol-exporter"` |  |
 | exporter.configMap | object | `{}` |  |
 | exporter.deployment.additionalLabels | object | `{}` |  |
-| exporter.deployment.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].key | string | `"kubernetes.io/arch"` |  |
-| exporter.deployment.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].operator | string | `"In"` |  |
-| exporter.deployment.affinity.nodeAffinity.requiredDuringSchedulingIgnoredDuringExecution.nodeSelectorTerms[0].matchExpressions[0].values[0] | string | `"amd64"` |  |
 | exporter.deployment.args | list | `[]` |  |
 | exporter.deployment.command | string | `""` |  |
 | exporter.deployment.containerSecurityContext.allowPrivilegeEscalation | bool | `false` |  |
@@ -169,7 +166,7 @@ endoflife_failed_configs{} == 1
 | exporter.deployment.image.digest | string | `""` |  |
 | exporter.deployment.image.pullPolicy | string | `"IfNotPresent"` |  |
 | exporter.deployment.image.repository | string | `"saritasallc/eol-exporter"` |  |
-| exporter.deployment.image.tag | string | `"1.1.1"` |  |
+| exporter.deployment.image.tag | string | `"1.2.0"` |  |
 | exporter.deployment.initContainers | list | `[]` |  |
 | exporter.deployment.livenessProbe.enabled | bool | `true` |  |
 | exporter.deployment.livenessProbe.exec | object | `{}` |  |

--- a/charts/eol-exporter/values.yaml
+++ b/charts/eol-exporter/values.yaml
@@ -14,7 +14,7 @@ exporter:
       # Public image is available on:
       # https://hub.docker.com/r/saritasallc/eol-exporter/tags
       repository: saritasallc/eol-exporter
-      tag: 1.1.1
+      tag: 1.2.0
       digest: ''  # if set to a non empty value, digest takes precedence on the tag
       pullPolicy: IfNotPresent
     initContainers: []
@@ -111,15 +111,6 @@ exporter:
     additionalLabels: {}
     tolerations: []
     nodeSelector: {}
-    affinity:
-      nodeAffinity:
-        requiredDuringSchedulingIgnoredDuringExecution:
-          nodeSelectorTerms:
-            - matchExpressions:
-                - key: kubernetes.io/arch
-                  operator: In
-                  values:
-                    - amd64
     topologySpreadConstraints: {}
     revisionHistoryLimit: 5
   additionalContainers: []

--- a/charts/eol-exporter/values.yaml
+++ b/charts/eol-exporter/values.yaml
@@ -41,7 +41,7 @@ exporter:
         protocol: TCP
     volumeMounts:
       config:
-        mountPath: /workspace/app/config.yaml
+        mountPath: /app/config.yaml
         subPath: config.yaml
     volumes:
       config:


### PR DESCRIPTION
### Summary

Task: [USAWS-336](https://saritasa.atlassian.net/browse/USAWS-336)

<!--
Description should contain link to valid task in Jira, short description of the implemented feature.
Please ensure that actions passed.
-->

- update EOL chart 1.0.7
- EOL app 1.2.0

- adds dynamic discovery of AWS endpoints: AWS/Elasticache/EKS

```
  services:
    - aws/eks
    - aws/rds
    - aws/elasticache
  regions:
    - us-west-2
  searchByTag:
    Environment: prod
  exclude:
    - '-test$'
```

If region block is not present, it will use default region (same as the EOL pod)
If searchByTag is not present, it will add all endpoints without filtering
if exclude is not present, it will add all endpoints discovered

- add ARM64 support

nodeAffinity for amd64 was dropped, pods can be scheduled in prometheus nodes now

<img width="2478" height="1418" alt="image" src="https://github.com/user-attachments/assets/68809a03-1bca-4eb7-a98d-3300431bb605" />

https://github.com/saritasa-nest/saritasa-devops-tools-eol-exporter/pull/9
https://github.com/saritasa-nest/saritasa-devops-tools-eol-exporter/pull/10


[USAWS-336]: https://saritasa.atlassian.net/browse/USAWS-336?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ